### PR TITLE
🔖 Bump version to 0.2.1 for release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "circuit_synth"
-version = "0.2.0"
+version = "0.2.1"
 description = "Pythonic circuit design for production-ready KiCad projects"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/circuit_synth/__init__.py
+++ b/src/circuit_synth/__init__.py
@@ -14,7 +14,7 @@ Or in Python:
     setup_claude_integration()
 """
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 
 # Dependency injection imports
 # Exception imports


### PR DESCRIPTION
Version bump to 0.2.1 for PyPI release.

This follows the major release merge and prepares for PyPI publication.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>