### PR TITLE
🔖 Version bump to 0.2.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "circuit_synth"
-version = "0.2.1"
+version = "0.2.2"
 description = "Pythonic circuit design for production-ready KiCad projects"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/circuit_synth/__init__.py
+++ b/src/circuit_synth/__init__.py
@@ -14,7 +14,7 @@ Or in Python:
     setup_claude_integration()
 """
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"
 
 # Dependency injection imports
 # Exception imports


### PR DESCRIPTION
Version bump to 0.2.2 for PyPI release with latest architectural improvements from develop merge.