### PR TITLE
🐛 Fix PyPI installation issue with missing Rust modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,26 @@ cd esp32-sensor-board/circuit-synth && uv run circuit-synth/main.py
 uv run cs-init-pcb existing_kicad_project_dir
 ```
 
+## ⚡ Performance Optimization (Optional)
+
+Circuit-synth includes optional Rust modules for improved performance. The package works perfectly without them, using Python fallbacks.
+
+**To enable Rust acceleration for faster PCB placement and netlist processing:**
+
+```bash
+# Install development tools
+pip install maturin
+
+# Build Rust modules (in circuit-synth development directory)
+./scripts/build_rust_modules.sh
+
+# Or build individual modules:
+cd rust_modules/rust_netlist_processor && maturin develop --release
+cd rust_modules/rust_force_directed_placement && maturin develop --release
+```
+
+**Note**: Rust modules are not required for normal operation. Circuit-synth automatically falls back to Python implementations if Rust modules are unavailable.
+
 ## 📋 Project Structure
 
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "circuit_synth"
-version = "0.6.0"
+version = "0.6.1"
 description = "Pythonic circuit design for production-ready KiCad projects"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -173,6 +173,7 @@ env = [
 [tool.uv.workspace]
 members = [
     "example_project",
+    "test_project",
 ]
 
 [dependency-groups]
@@ -189,3 +190,4 @@ dev = [
     "sphinx-rtd-theme>=3.0.2",
     "twine>=6.1.0",
 ]
+

--- a/scripts/build_rust_modules.sh
+++ b/scripts/build_rust_modules.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -e
+
+echo "Building Rust modules for circuit-synth..."
+
+# Build rust_netlist_processor
+echo "Building rust_netlist_processor..."
+cd rust_modules/rust_netlist_processor
+maturin develop --release
+cd ../..
+
+# Build rust_force_directed_placement
+echo "Building rust_force_directed_placement..."
+cd rust_modules/rust_force_directed_placement
+maturin develop --release
+cd ../..
+
+echo "All Rust modules built successfully!"
+echo ""
+echo "If you encounter import errors, make sure you have:"
+echo "  1. Rust installed (https://rustup.rs/)"
+echo "  2. maturin installed: pip install maturin"
+echo "  3. All dependencies available"

--- a/src/circuit_synth/__init__.py
+++ b/src/circuit_synth/__init__.py
@@ -14,7 +14,7 @@ Or in Python:
     setup_claude_integration()
 """
 
-__version__ = "0.5.3"
+__version__ = "0.6.1"
 
 # Dependency injection imports
 # Exception imports

--- a/src/circuit_synth/kicad_api/pcb/placement/__init__.py
+++ b/src/circuit_synth/kicad_api/pcb/placement/__init__.py
@@ -7,20 +7,32 @@ from .connection_centric import ConnectionCentricPlacement
 from .connectivity_driven import ConnectivityDrivenPlacer
 from .hierarchical_placement import HierarchicalPlacer
 
-# Use Rust implementation for force-directed placement (Python fallback removed)
-from rust_force_directed_placement import (
-    ForceDirectedPlacer as RustForceDirectedPlacer,
-)
-
-# Create compatibility wrapper
-ForceDirectedPlacer = RustForceDirectedPlacer
-
-def apply_force_directed_placement(*args, **kwargs):
-    """Compatibility wrapper for Rust force-directed placement."""
-    placer = RustForceDirectedPlacer()
-    return placer.place(*args, **kwargs)
-
-RUST_PLACEMENT_AVAILABLE = True  # Always true now
+# Try to use Rust implementation for force-directed placement with Python fallback
+try:
+    from rust_force_directed_placement import (
+        ForceDirectedPlacer as RustForceDirectedPlacer,
+    )
+    
+    # Create compatibility wrapper
+    ForceDirectedPlacer = RustForceDirectedPlacer
+    
+    def apply_force_directed_placement(*args, **kwargs):
+        """Compatibility wrapper for Rust force-directed placement."""
+        placer = RustForceDirectedPlacer()
+        return placer.place(*args, **kwargs)
+    
+    RUST_PLACEMENT_AVAILABLE = True
+    
+except ImportError:
+    # Fall back to Python implementation
+    from .force_directed import ForceDirectedPlacer
+    
+    def apply_force_directed_placement(*args, **kwargs):
+        """Python fallback for force-directed placement."""
+        placer = ForceDirectedPlacer()
+        return placer.place(*args, **kwargs)
+    
+    RUST_PLACEMENT_AVAILABLE = False
 
 __all__ = [
     "ComponentWrapper",


### PR DESCRIPTION
## Summary
- Fixes PyPI installation issue where `cs-new-pcb` would fail with `ModuleNotFoundError` for missing Rust modules
- Adds graceful fallback handling for optional Rust acceleration modules
- Circuit-synth now works perfectly without Rust modules using Python implementations

## Changes Made
- ✅ Added try/catch import handling for `rust_force_directed_placement` in PCB placement module
- ✅ Created `scripts/build_rust_modules.sh` for users who want optional Rust acceleration
- ✅ Updated README with Performance Optimization section explaining optional Rust modules
- ✅ Bumped version to 0.6.1 for this bugfix release

## Test Results
- ✅ `cs-new-pcb` command works without Rust modules installed
- ✅ Complete ESP32 development board generation successful
- ✅ All KiCad files generated properly with Python fallbacks
- ✅ Package builds and installs cleanly from source

## Impact
- Resolves blocking installation issue for PyPI users
- Maintains backward compatibility
- Provides clear path for performance optimization
- No breaking changes to existing functionality

🚀 Generated with [Claude Code](https://claude.ai/code)