### PR TITLE
🐛 Fix runtime netlist generation error without Rust modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ cd my_circuit_project
 uv add circuit-synth
 
 # Setup complete project template
-uv run cs-new-project
+uv run cs-new-pcb
 
 # Generate complete KiCad project  
 uv run python circuit-synth/main.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "circuit_synth"
-version = "0.6.1"
+version = "0.6.2"
 description = "Pythonic circuit design for production-ready KiCad projects"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/circuit_synth/__init__.py
+++ b/src/circuit_synth/__init__.py
@@ -14,7 +14,7 @@ Or in Python:
     setup_claude_integration()
 """
 
-__version__ = "0.6.1"
+__version__ = "0.6.2"
 
 # Dependency injection imports
 # Exception imports

--- a/src/circuit_synth/core/netlist_exporter.py
+++ b/src/circuit_synth/core/netlist_exporter.py
@@ -41,10 +41,29 @@ except ImportError as e:
     RUST_NETLIST_AVAILABLE = False
     RUST_NETLIST_PROCESSOR = None
     
-    # No fallback - require Rust implementation
-    def convert_json_to_netlist(json_data, output_path):
-        """Placeholder - Rust implementation required."""
-        raise CircuitSynthError("rust_netlist_processor not available - run: maturin develop --release")
+    # Python fallback implementation
+    def convert_json_to_netlist(json_file_path, output_path):
+        """Python fallback for netlist conversion when Rust is unavailable."""
+        try:
+            # Import the Python netlist exporter
+            from ..kicad.netlist_exporter import generate_netlist
+            
+            # Read the JSON file
+            with open(json_file_path, 'r') as f:
+                circuit_data = json.load(f)
+            
+            # Generate KiCad netlist using Python implementation
+            netlist_content = generate_netlist(circuit_data)
+            
+            # Write to output file
+            with open(output_path, 'w') as f:
+                f.write(netlist_content)
+                
+            defensive_logger.info("Python fallback: Successfully generated KiCad netlist at %s", output_path)
+            
+        except Exception as e:
+            defensive_logger.error("Python fallback failed: %s", e)
+            raise CircuitSynthError(f"Failed to generate netlist with Python fallback: {e}")
 
 
 def convert_python_to_rust_format(circuit_data: dict) -> dict:


### PR DESCRIPTION
## Summary
- Fixes runtime error when `rust_netlist_processor` is unavailable
- Adds proper Python fallback for netlist generation using existing kicad.netlist_exporter
- Circuit generation now works completely without Rust modules
- Resolves `CircuitSynthError: rust_netlist_processor not available` error

## Changes Made
- ✅ Replace placeholder error function with proper Python fallback in `convert_json_to_netlist`
- ✅ Use existing `kicad.netlist_exporter.generate_netlist` function for Python fallback
- ✅ Maintain proper error handling and logging
- ✅ Bump version to 0.6.2 for this critical bugfix

## Test Results  
- ✅ Circuit generation works without Rust modules
- ✅ KiCad netlist (.net) files generated successfully with Python fallback
- ✅ No breaking changes to existing functionality
- ✅ Maintains compatibility with optional Rust acceleration

## Impact
Users can now run complete circuit generation workflow from PyPI installation:
```bash
uv add circuit-synth
uv run cs-new-pcb
cd circuit-synth && uv run python main.py  # Works without errors
```

This resolves the critical blocker where PyPI users couldn't generate circuits.

🚀 Generated with [Claude Code](https://claude.ai/code)