### PR TITLE
🐛 Fix directory creation in Python netlist fallback

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "circuit_synth"
-version = "0.6.2"
+version = "0.6.3"
 description = "Pythonic circuit design for production-ready KiCad projects"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/circuit_synth/__init__.py
+++ b/src/circuit_synth/__init__.py
@@ -14,7 +14,7 @@ Or in Python:
     setup_claude_integration()
 """
 
-__version__ = "0.6.2"
+__version__ = "0.6.3"
 
 # Dependency injection imports
 # Exception imports

--- a/src/circuit_synth/core/netlist_exporter.py
+++ b/src/circuit_synth/core/netlist_exporter.py
@@ -47,6 +47,11 @@ except ImportError as e:
         try:
             # Import the Python netlist exporter
             from ..kicad.netlist_exporter import generate_netlist
+            from pathlib import Path
+            
+            # Ensure output directory exists
+            output_file = Path(output_path)
+            output_file.parent.mkdir(parents=True, exist_ok=True)
             
             # Read the JSON file
             with open(json_file_path, 'r') as f:


### PR DESCRIPTION
## Summary
- Fixes critical FileNotFoundError when Python fallback tries to write netlist
- Python fallback now creates parent directories before writing output
- Resolves `[Errno 2] No such file or directory` error in netlist generation

## Changes Made
- ✅ Add `Path.mkdir(parents=True, exist_ok=True)` to ensure output directory exists
- ✅ Import `pathlib.Path` in fallback function
- ✅ Bump version to 0.6.3 for this critical fix

## Test Results  
- ✅ Netlist generation now works without directory creation errors
- ✅ Maintains backward compatibility
- ✅ No breaking changes to existing functionality

## Impact
Users can now run complete circuit generation from PyPI without directory errors:
```bash
cd circuit-synth && uv run python main.py  # ✅ Works without FileNotFoundError
```

This resolves the critical error where netlist generation failed due to missing output directories.

🚀 Generated with [Claude Code](https://claude.ai/code)