### PR TITLE
🐛 Fix PCB placement module import error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "circuit_synth"
-version = "0.6.3"
+version = "0.6.4"
 description = "Pythonic circuit design for production-ready KiCad projects"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/circuit_synth/__init__.py
+++ b/src/circuit_synth/__init__.py
@@ -14,7 +14,7 @@ Or in Python:
     setup_claude_integration()
 """
 
-__version__ = "0.6.3"
+__version__ = "0.6.4"
 
 # Dependency injection imports
 # Exception imports

--- a/src/circuit_synth/pcb/placement/__init__.py
+++ b/src/circuit_synth/pcb/placement/__init__.py
@@ -7,20 +7,24 @@ from .connection_centric import ConnectionCentricPlacement
 from .connectivity_driven import ConnectivityDrivenPlacer
 from .hierarchical_placement import HierarchicalPlacer
 
-# Use Rust implementation for force-directed placement (Python fallback removed)
-from rust_force_directed_placement import (
-    ForceDirectedPlacer as RustForceDirectedPlacer,
-)
-
-# Create compatibility wrapper
-ForceDirectedPlacer = RustForceDirectedPlacer
+# Use Rust implementation for force-directed placement with Python fallback
+try:
+    from rust_force_directed_placement import (
+        ForceDirectedPlacer as RustForceDirectedPlacer,
+    )
+    ForceDirectedPlacer = RustForceDirectedPlacer
+    PCB_RUST_PLACEMENT_AVAILABLE = True
+except ImportError:
+    # Python fallback for placement
+    from .force_directed import ForceDirectedPlacer
+    PCB_RUST_PLACEMENT_AVAILABLE = False
 
 def apply_force_directed_placement(*args, **kwargs):
-    """Compatibility wrapper for Rust force-directed placement."""
-    placer = RustForceDirectedPlacer()
+    """Compatibility wrapper for force-directed placement with fallback."""
+    placer = ForceDirectedPlacer()
     return placer.place(*args, **kwargs)
 
-RUST_PLACEMENT_AVAILABLE = True  # Always true now
+RUST_PLACEMENT_AVAILABLE = PCB_RUST_PLACEMENT_AVAILABLE
 
 __all__ = [
     "ComponentWrapper",

--- a/uv.lock
+++ b/uv.lock
@@ -292,7 +292,7 @@ wheels = [
 
 [[package]]
 name = "circuit-synth"
-version = "0.5.3"
+version = "0.6.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary
- Fixes critical ModuleNotFoundError for `rust_force_directed_placement` in PCB generation
- Adds graceful Python fallback for PCB placement when Rust modules unavailable  
- Complete circuit generation now works without any Rust dependencies

## Changes Made
- ✅ Add try/catch wrapper around `rust_force_directed_placement` import
- ✅ Use Python `force_directed.ForceDirectedPlacer` as fallback
- ✅ Update compatibility functions to use fallback properly
- ✅ Bump version to 0.6.4 for this critical fix

## Test Results  
- ✅ KiCad project generation works without Rust placement modules
- ✅ Netlist generation already working from v0.6.3
- ✅ Complete end-to-end circuit workflow functional
- ✅ No breaking changes to existing functionality

## Impact
Users can now run complete circuit → KiCad workflow from PyPI:
```bash
cd circuit-synth && uv run python main.py  # ✅ Works completely without Rust
```

This resolves the final critical blocker where PCB generation failed due to missing Rust modules.

🚀 Generated with [Claude Code](https://claude.ai/code)