### PR TITLE
🔖 Update version to 0.6.6 for release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "circuit_synth"
-version = "0.6.5"
+version = "0.6.6"
 description = "Pythonic circuit design for production-ready KiCad projects"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/circuit_synth/__init__.py
+++ b/src/circuit_synth/__init__.py
@@ -14,7 +14,7 @@ Or in Python:
     setup_claude_integration()
 """
 
-__version__ = "0.6.5"
+__version__ = "0.6.6"
 
 # Dependency injection imports
 # Exception imports


### PR DESCRIPTION
This PR updates the version number to 0.6.6 on main branch for the PyPI release.

- Updates pyproject.toml version to 0.6.6
- Updates __init__.py __version__ to 0.6.6

This is required for the PyPI release process.