### PR TITLE
🔖 Version bump to 0.7.2 (post-release hotfix)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "circuit_synth"
-version = "0.7.1"
+version = "0.7.2"
 description = "Pythonic circuit design for production-ready KiCad projects"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/circuit_synth/__init__.py
+++ b/src/circuit_synth/__init__.py
@@ -14,7 +14,7 @@ Or in Python:
     setup_claude_integration()
 """
 
-__version__ = "0.7.1"
+__version__ = "0.7.2"
 
 # Plugin integration
 from .ai_integration.plugins import AIDesignBridge


### PR DESCRIPTION
## Post-Release Version Sync

This hotfix ensures main branch has the correct version 0.7.2 in pyproject.toml and __init__.py to match the published release.

### Changes
- Update pyproject.toml version to 0.7.2
- Update src/circuit_synth/__init__.py version to 0.7.2

### Context
The release v0.7.2 was successfully published to PyPI and tagged, but the version bump commit couldn't be pushed to protected main branch. This PR syncs the version numbers.

**Post-merge**: Main branch will be in sync with the published release.