### PR TITLE
Add circuit-intelligence as submodule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@ test_outputs/
 *.kicad_sch-bak
 
 # Submodules in development
-submodules/circuit-intelligence/
 
 # C extensions
 *.so

--- a/.gitmodules
+++ b/.gitmodules
@@ -37,3 +37,6 @@
 [submodule "submodules/kicad-sch-api"]
 	path = submodules/kicad-sch-api
 	url = git@github.com:circuit-synth/kicad-sch-api.git
+[submodule "submodules/circuit-intelligence"]
+	path = submodules/circuit-intelligence
+	url = https://github.com/circuit-synth/circuit-intelligence


### PR DESCRIPTION
## Summary
- Added circuit-intelligence repository as a git submodule
- Removed circuit-intelligence from .gitignore to allow tracking as submodule
- Located at `submodules/circuit-intelligence`

## Changes
- Modified `.gitignore` to remove the circuit-intelligence exclusion
- Added circuit-intelligence as a proper git submodule in `submodules/`
- Updated `.gitmodules` with the new submodule configuration

🤖 Generated with [Claude Code](https://claude.ai/code)