### PR TITLE
Clean up README: concise, add code-based design philosophy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,77 +1,167 @@
 # circuit-synth
 
-**Python-based circuit design with KiCad integration and AI acceleration.**
+Python-based circuit design with KiCad integration and AI acceleration.
 
-Generate professional KiCad projects from Python code with hierarchical design, version control, and automated documentation.
+## What is Code-Based Circuit Design?
+
+Circuit-synth brings software engineering practices to hardware design by letting you define circuits in Python code instead of clicking and dragging in a GUI. Your circuit becomes a program: testable, version-controlled, and composable.
+
+### Traditional Visual CAD Workflow
+
+In traditional EDA tools like KiCad, Altium, or Eagle, you:
+- Click to place each component on a canvas
+- Manually draw wires between pins
+- Copy-paste repeated circuit patterns
+- Track changes with screenshots or "before/after" project files
+- Search through menus to find the right component symbol
+- Manually verify that all connections are correct
+
+This visual approach works for simple circuits, but becomes unwieldy as designs grow. Making systematic changes requires clicking through every instance. Reusing proven circuit blocks means copying between projects. Code review happens by comparing images or clicking through schematics.
+
+### Code-Based Circuit Design
+
+With circuit-synth, you write Python code:
+
+```python
+@circuit(name="Power_Supply")
+def power_supply(vbus_in, vcc_3v3_out, gnd):
+    regulator = Component(
+        symbol="Regulator_Linear:AMS1117-3.3",
+        ref="U",
+        footprint="Package_TO_SOT_SMD:SOT-223-3_TabPin2"
+    )
+
+    cap_in = Component(symbol="Device:C", ref="C", value="10uF")
+    cap_out = Component(symbol="Device:C", ref="C", value="22uF")
+
+    regulator["VI"] += vbus_in
+    regulator["VO"] += vcc_3v3_out
+    regulator["GND"] += gnd
+
+    cap_in[1] += vbus_in
+    cap_in[2] += gnd
+    cap_out[1] += vcc_3v3_out
+    cap_out[2] += gnd
+```
+
+This circuit is now a **reusable function**. Need 5 power supplies? Call `power_supply()` five times. Need to change all decoupling caps? Update one line. Want to review what changed? `git diff` shows exactly which connections were modified.
+
+### Key Benefits
+
+**Version Control**: Every change is tracked with git. See exactly what changed, when, and why. Branch to try alternative designs. Merge proven improvements from other engineers.
+
+**Modularity**: Build circuits from tested subcircuits. A USB-C power delivery circuit becomes a function you can reuse across projects. Change the implementation once, update everywhere.
+
+**Code Review**: Team members review circuit changes like code. Diff shows "changed R1 from 10k to 4.7k" instead of visual schematic comparison. Catch mistakes before manufacturing.
+
+**Automation**: Generate parametric designs. Write a function that creates a filter circuit for any cutoff frequency. Batch-generate variants for A/B testing.
+
+**Testing**: Validate circuits with unit tests. Assert that power supply output is 3.3V ±5%. Run SPICE simulation in CI/CD. Catch regressions automatically.
+
+**AI-Friendly**: LLMs can read and write circuit-synth code directly. Natural language → working circuit. This is one of the most powerful advantages of circuits-as-code: AI can understand, generate, and modify circuit designs through natural conversation.
+
+**Refactoring**: Extract repeated patterns into functions. Rename nets across entire design. Reorganize hierarchy without manual rewiring.
+
+### Claude Code Integration
+
+Circuit-synth includes extensive Claude Code integration, making AI-assisted circuit design practical and powerful. When you create a circuit-synth project, you get:
+
+**17 Specialized AI Agents**: Domain experts for different aspects of circuit design:
+- `circuit-architect`: Complete system design from requirements
+- `circuit-synth`: Generate production-ready Python code
+- `simulation-expert`: SPICE analysis and optimization
+- `component-search`: Real-time component sourcing across suppliers
+- Plus agents for debugging, testing, FMEA analysis, and more
+
+**18 Slash Commands**: Quick access to common operations:
+- `/find-symbol STM32` - Search for KiCad symbols
+- `/find-parts "0.1uF 0603"` - Component availability and pricing
+- `/generate-validated-circuit "buck converter 5V to 3.3V"` - Natural language → working code
+- `/analyze-fmea my_circuit.py` - Automated reliability analysis
+
+**Natural Language Circuit Design**: Describe what you want in plain English, get working circuit-synth code:
+```
+You: "Design a USB-C power delivery circuit with 20V output and overcurrent protection"
+Claude: [Generates complete power_supply.py with proper components, verified availability, and safety features]
+```
+
+This integration makes circuit-synth approachable for beginners while accelerating experts. The AI handles component selection, library lookups, and boilerplate code, letting you focus on design intent.
+
+### When Code-Based Design Excels
+
+- **Parametric designs**: Circuits that come in many variants (different voltages, channel counts, etc.)
+- **Repeated blocks**: Designs with multiple identical subcircuits (multi-channel systems, arrays)
+- **Team collaboration**: Multiple engineers working on the same design simultaneously
+- **Rapid iteration**: Frequent design changes that would require tedious manual updates
+- **Complex systems**: Large hierarchical designs that benefit from modular organization
+- **AI-assisted design**: Generating circuits from specifications or optimizing existing designs
+
+### Integration with KiCad
+
+Circuit-synth is designed to work **with** existing KiCad workflows, not replace them. You can adopt circuit-synth at any stage of your design process.
+
+**Bi-Directional Workflow**: Circuit-synth isn't just code → KiCad. It's fully bi-directional:
+- **Start in Python**: Generate initial design from circuit-synth code
+- **Start in KiCad**: Import existing .kicad_sch files into Python for modification
+- **Iterate**: Make changes in either Python or KiCad, re-import/re-export as needed
+- **Hybrid approach**: Use Python for hierarchical structure and repeated blocks, KiCad for custom layout
+
+You can import an existing KiCad project, modify it in Python (add a subcircuit, change component values, etc.), and export back to KiCad. This makes circuit-synth a powerful tool for:
+- Automating changes to existing designs
+- Extracting reusable subcircuits from legacy projects
+- Adding parametric generation to hand-drawn schematics
+- Batch-updating component values across multiple projects
+
+**After code generation**, use KiCad normally:
+- Visual schematic editing and verification
+- PCB layout and routing with KiCad's tools
+- DRC, ERC, and 3D visualization
+- Manufacturing export (Gerbers, drill files, BOM, pick-and-place)
+
+You get the best of both worlds: code-based definition with visual refinement.
 
 ## Installation
 
 ```bash
-# Install with uv (recommended)
 uv add circuit-synth
-
-# Or with pip
+# or
 pip install circuit-synth
 ```
-
-## Configuration
-
-### Logging Control
-
-By default, circuit-synth runs with minimal logging output (WARNING level). To enable detailed logs for debugging:
-
-```bash
-# Enable verbose logging via environment variable
-export CIRCUIT_SYNTH_LOG_LEVEL=INFO
-
-# Or set it in your Python script
-import os
-os.environ['CIRCUIT_SYNTH_LOG_LEVEL'] = 'INFO'
-```
-
-Available log levels:
-- `ERROR`: Only show errors
-- `WARNING`: Show warnings and errors (default)
-- `INFO`: Show informational messages, progress updates
-- `DEBUG`: Show detailed debugging information
 
 ## Quick Start
 
 ```bash
-# Create new project with example circuit
-uv run cs-new-project
+# Create new project with ESP32-C6 example
+cs-new-project
 
-# This generates a complete ESP32-C6 development board
-cd circuit-synth && uv run python example_project/circuit-synth/main.py
+# Generate KiCad files
+cd circuit-synth && uv run python circuit-synth/main.py
 ```
 
-## Example: Power Supply Circuit
+## Example Circuit
 
 ```python
 from circuit_synth import *
 
 @circuit(name="Power_Supply")
 def power_supply(vbus_in, vcc_3v3_out, gnd):
-    """5V to 3.3V power regulation subcircuit"""
-    
-    # Components with KiCad integration
+    """5V to 3.3V power regulation"""
+
     regulator = Component(
-        symbol="Regulator_Linear:AMS1117-3.3", 
+        symbol="Regulator_Linear:AMS1117-3.3",
         ref="U",
         footprint="Package_TO_SOT_SMD:SOT-223-3_TabPin2"
     )
-    
-    # Input/output capacitors
+
     cap_in = Component(symbol="Device:C", ref="C", value="10uF",
                       footprint="Capacitor_SMD:C_0805_2012Metric")
     cap_out = Component(symbol="Device:C", ref="C", value="22uF",
                        footprint="Capacitor_SMD:C_0805_2012Metric")
-    
-    # Explicit connections
-    regulator["VI"] += vbus_in    # Input pin
-    regulator["VO"] += vcc_3v3_out # Output pin
+
+    regulator["VI"] += vbus_in
+    regulator["VO"] += vcc_3v3_out
     regulator["GND"] += gnd
-    
+
     cap_in[1] += vbus_in
     cap_in[2] += gnd
     cap_out[1] += vcc_3v3_out
@@ -79,290 +169,170 @@ def power_supply(vbus_in, vcc_3v3_out, gnd):
 
 @circuit(name="Main_Circuit")
 def main_circuit():
-    """Complete circuit with hierarchical design"""
-    
-    # Create shared nets
     vbus = Net('VBUS')
     vcc_3v3 = Net('VCC_3V3')
     gnd = Net('GND')
-    
-    # Use the power supply subcircuit
+
     power_circuit = power_supply(vbus, vcc_3v3, gnd)
 
-# Generate KiCad project
 if __name__ == "__main__":
     circuit = main_circuit()
     circuit.generate_kicad_project("my_board")
 ```
 
-## Core Features
+## Features
 
-- **Professional KiCad Output**: Generate .kicad_pro, .kicad_sch, .kicad_pcb files with modern kicad-sch-api integration
-- **Hierarchical Design**: Modular subcircuits like software modules  
-- **Atomic KiCad Operations**: Add/remove individual components from existing schematics with rollback safety
-- **Modern KiCad Integration**: Uses PyPI kicad-sch-api (v0.1.1+) for professional schematic generation
-- **Component Intelligence**: JLCPCB & DigiKey integration, symbol/footprint verification
-- **Fast JLCPCB Search**: Direct search with 80% speed improvement, 90% less tokens
-- **AI Integration**: Claude Code agents for automated design assistance
-- **Circuit Debugging**: AI-powered PCB troubleshooting with systematic fault-finding
-- **FMEA Analysis**: Comprehensive reliability analysis with physics-based failure models
-- **Test Generation**: Automated test plans for validation
-- **Version Control**: Git-friendly text-based circuit definitions
+- **Professional KiCad Output**: Generate complete .kicad_pro, .kicad_sch, .kicad_pcb projects
+- **Hierarchical Design**: Build modular circuits with reusable subcircuits like software functions
+- **Component Intelligence**: Real-time JLCPCB & DigiKey availability, pricing, and alternatives
+- **AI-Powered Design**: Specialized Claude Code agents for automated circuit generation and optimization
+- **SPICE Simulation**: Built-in circuit validation with DC, AC, and transient analysis
+- **Version Control Friendly**: Text-based Python definitions work seamlessly with git
+- **Manufacturing Ready**: Automatic BOM generation with verified component availability
 
-## KiCad-sch-api Integration
-
-Circuit-synth integrates with the modern **kicad-sch-api** PyPI package - a valuable standalone tool that was extracted from circuit-synth for broader community use.
-
-### Benefits of kicad-sch-api
-- **Professional KiCad Files**: Generates industry-standard .kicad_sch files with proper formatting
-- **Symbol Library Integration**: Full access to KiCad's extensive symbol libraries  
-- **Hierarchical Support**: Clean handling of complex multi-sheet designs
-- **Version Compatibility**: Works with modern KiCad versions (v7.0+)
-
-### Hybrid Architecture
-Circuit-synth uses a hybrid approach combining the best of both worlds:
-- **Legacy System**: Handles component positioning and hierarchical structure
-- **Modern API**: Professional schematic file writing via kicad-sch-api
-- **Intelligent Selection**: Automatically chooses the right approach per schematic type
-
-```python
-# The modern API integration is automatic - just use circuit-synth as normal!
-@circuit(name="MyCircuit")
-def my_design():
-    # Your circuit design here
-    pass
-
-# Behind the scenes: circuit-synth + kicad-sch-api = professional results
-```
-
-### Standalone kicad-sch-api Usage
-The kicad-sch-api package is also valuable as a standalone tool for Python KiCad integration:
+## Configuration
 
 ```bash
-pip install kicad-sch-api
+# Enable detailed logging
+export CIRCUIT_SYNTH_LOG_LEVEL=INFO  # ERROR, WARNING, INFO, DEBUG
 ```
 
-Visit the [kicad-sch-api repository](https://github.com/circuit-synth/kicad-sch-api) for standalone usage examples.
+## Claude Code Integration
 
-## AI-Powered Design
+Circuit-synth projects include specialized AI agents for automated design workflows.
 
-### Claude Code Commands
-
-```bash
-# AI agent commands (with Claude Code)
-/find-symbol STM32                    # Search KiCad symbols
-/find-footprint LQFP64                # Find footprints  
-/generate-validated-circuit "ESP32 IoT sensor" mcu
-
-# Circuit debugging commands (NEW!)
-/debug-start "Board not powering on" --board="my_board"
-/debug-measure "VCC: 3.3V, GND: 0V"
-/debug-analyze                        # Get AI analysis
-/debug-suggest                        # Next troubleshooting steps
-```
-
-### 🤖 Claude Code Agents
-
-Circuit-synth includes specialized AI agents for different aspects of circuit design. Each agent has deep expertise in their domain:
-
-#### **circuit-architect** - Master Circuit Design Coordinator
-- **Use for**: Complex multi-component designs, system-level architecture
-- **Expertise**: Circuit topology planning, component selection, design trade-offs
-- **Example**: *"Design a complete IoT sensor node with power management, wireless connectivity, and sensor interfaces"*
-
-#### **circuit-synth** - Circuit Code Generation Specialist  
-- **Use for**: Converting natural language to working Python circuit code
-- **Expertise**: circuit-synth syntax, KiCad integration, hierarchical design patterns
-- **Example**: *"Generate Python code for a USB-C PD trigger circuit with 20V output"*
-
-#### **simulation-expert** - SPICE Simulation and Circuit Validation
-- **Use for**: Circuit analysis, performance optimization, validation
-- **Expertise**: SPICE simulation setup, component modeling, performance analysis
-- **Example**: *"Simulate this amplifier circuit and optimize for 40dB gain with <100mW power"*
-
-#### **circuit-debugger** - AI-Powered PCB Troubleshooting Specialist (NEW!)
-- **Use for**: Hardware debugging, fault-finding, troubleshooting non-working boards
-- **Expertise**: Systematic debugging, test equipment usage, failure pattern recognition
-- **Example**: *"My board isn't powering on - help me debug the issue step by step"*
-
-#### **component-search** - Multi-Source Component Search
-- **Use for**: Component selection across all suppliers, price comparison, availability checking
-- **Expertise**: JLCPCB, DigiKey, and future suppliers (Mouser, LCSC, etc.)
-- **Example**: *"Find 0.1uF 0603 capacitors across all suppliers with pricing comparison"*
-
-#### **jlc-parts-finder** - JLCPCB Component Intelligence
-- **Use for**: Real-time component availability, pricing, and alternatives
-- **Expertise**: JLCPCB catalog search, stock levels, KiCad symbol verification
-- **Example**: *"Find STM32 with 3 SPIs available on JLCPCB under $5"*
-
-#### **general-purpose** - Research and Analysis
-- **Use for**: Open-ended research, codebase analysis, complex searches
-- **Expertise**: Technical research, documentation analysis, multi-step problem solving
-- **Example**: *"Research best practices for EMI reduction in switching power supplies"*
-
-#### **test-plan-creator** - Test Plan Generation and Validation
-- **Use for**: Creating comprehensive test procedures for circuit validation
-- **Expertise**: Functional, performance, safety, and manufacturing test plans
-- **Example**: *"Generate test plan for ESP32 dev board with power measurements"*
-
-#### **fmea-analyzer** - Failure Mode and Effects Analysis
-- **Use for**: Reliability analysis, risk assessment, failure prediction
-- **Expertise**: Component failure modes, physics of failure, IPC Class 3 compliance
-- **Example**: *"Analyze my circuit for potential failure modes and generate FMEA report"*
-
-### Using Agents Effectively
+### Available Slash Commands
 
 ```bash
-# Start with circuit-architect for complex projects
-"Design an ESP32-based environmental monitoring station"
-
-# Use circuit-synth for code generation
-"Generate circuit-synth code for the power supply section"
-
-# Validate with simulation-expert
-"Simulate this buck converter and verify 3.3V output ripple"
-
-# Optimize with component-search
-"Replace expensive components with JLCPCB alternatives"
-```
-
-**Pro Tip**: Let the **circuit-architect** coordinate complex projects - it will automatically delegate to other specialists as needed!
-
-### **Agent Categories:**
-- **Circuit Design**: circuit-architect, circuit-synth, simulation-expert, test-plan-creator
-- **Development**: circuit_generation_agent, contributor, first_setup_agent  
-- **Manufacturing**: component-search, jlc-parts-finder, stm32-mcu-finder
-
-### **Command Categories:**
-- **Circuit Design**: analyze-design, find-footprint, find-symbol, validate-existing-circuit
-- **Development**: dev-run-tests, dev-update-and-commit, dev-review-branch
-- **Manufacturing**: find-parts, find-mcu, find_stm32
-- **Library Setup**: cs-library-setup, cs-setup-snapeda-api, cs-setup-digikey-api
-- **Test Planning**: create-test-plan, generate-manufacturing-tests
-- **Setup**: setup-kicad-plugins, setup_circuit_synth
-
-## 🚀 Commands
-
-### Project Creation
-```bash
-cs-new-project              # Complete project setup with ESP32-C6 example
-```
-
-### Circuit Generation
-```bash
-cd circuit-synth && uv run python example_project/circuit-synth/main.py    # Generate KiCad files from Python code
-```
-
-### Claude Code Slash Commands
-Available when working with Claude Code in a circuit-synth project:
-
-```bash
-# Component Search (with API fallback)
-/find-symbol STM32              # Local → DigiKey GitHub → SnapEDA/DigiKey APIs
-/find-footprint LQFP64          # Multi-source component search
-/find-stm32 "3 SPIs, USB"       # STM32 with specific peripherals
+# Component search
+/find-symbol STM32              # Search KiCad symbol libraries
+/find-footprint LQFP64          # Find component footprints
+/find-parts "0.1uF 0603"        # Search across all suppliers
+/find-stm32 "3 SPIs, USB"       # STM32-specific search
 
 # Circuit generation
 /generate-validated-circuit "ESP32 IoT sensor" mcu
-/validate-existing-circuit      # Validate current circuit code
+/validate-existing-circuit
 
-# Component Intelligence  
-/find-parts "0.1uF 0603 X7R capacitor"               # Search all suppliers
-/find-parts "STM32F407" --source jlcpcb              # JLCPCB only
-/find-parts "LM358" --compare                        # Compare across suppliers
-/find-stm32 "3 SPIs, USB, available JLCPCB"          # STM32-specific search
-
-# Fast JLCPCB CLI (no agents, 80% faster)
-jlc-fast search STM32G4            # Direct search
-jlc-fast cheapest "10uF 0805"      # Find cheapest option
-jlc-fast most-available LM358      # Find highest stock
-
-# FMEA analysis
-/analyze-fmea my_circuit.py     # Run FMEA analysis on circuit
+# Analysis
+/analyze-fmea my_circuit.py     # Reliability analysis
 ```
 
-### Specialized AI Agents
+### AI Agents
 
-When working with Claude Code, these agents provide domain expertise:
+- **circuit-architect**: Complete system-level design and architecture planning
+- **circuit-synth**: Generate production-ready circuit-synth Python code
+- **simulation-expert**: SPICE simulation setup and performance optimization
+- **component-search**: Multi-source component search with price/availability comparison
+- **jlc-parts-finder**: Real-time JLCPCB stock levels and pricing
+- **test-plan-creator**: Automated test procedure generation
 
-- **circuit-architect**: Overall circuit design and system architecture
-- **circuit-synth**: Python code generation for circuits  
-- **simulation-expert**: SPICE simulation and validation
-- **component-guru**: Component selection and JLCPCB sourcing
-- **jlc-parts-finder**: Real-time JLCPCB availability checking
-- **stm32-mcu-finder**: STM32 peripheral search and selection
-- **test-plan-creator**: Automated test plan generation
-- **fmea-analyzer**: Reliability analysis and failure prediction
+## Component Search
 
-## ⚡ Atomic KiCad Operations
+### Multi-Source Search
 
-Circuit-synth provides atomic operations for surgical modifications to existing KiCad schematics, enabling incremental updates without regenerating entire projects:
-
-### Production API
+Search across JLCPCB, DigiKey, and other suppliers with unified interface:
 
 ```python
-from circuit_synth.kicad.atomic_integration import AtomicKiCadIntegration, migrate_circuit_to_atomic
+from circuit_synth.manufacturing import find_parts
 
-# Initialize atomic integration for a KiCad project
-atomic = AtomicKiCadIntegration("/path/to/project")
+# Search all suppliers
+results = find_parts("0.1uF 0603 X7R", sources="all")
 
-# Add components using atomic operations
-atomic.add_component_atomic("main", {
-    'symbol': 'Device:R',
-    'ref': 'R1',
-    'value': '10k',
-    'footprint': 'Resistor_SMD:R_0603_1608Metric',
-    'position': (100, 80)
-})
+# Specific supplier only
+jlc_results = find_parts("STM32F407", sources="jlcpcb")
+dk_results = find_parts("LM358", sources="digikey")
 
-# Remove components
-atomic.remove_component_atomic("main", "R1")
-
-# Fix hierarchical main schematics with sheet references
-subcircuits = [
-    {"name": "USB_Port", "filename": "USB_Port.kicad_sch", "position": (35, 35), "size": (43, 25)},
-    {"name": "Power_Supply", "filename": "Power_Supply.kicad_sch", "position": (95, 35), "size": (44, 20)}
-]
-atomic.fix_hierarchical_main_schematic(subcircuits)
-
-# Migrate JSON netlist to KiCad using atomic operations
-migrate_circuit_to_atomic("circuit.json", "output_project/")
+# Compare pricing and availability
+comparison = find_parts("3.3V regulator", sources="all", compare=True)
 ```
 
-### Key Benefits
+### Fast JLCPCB Search
 
-- **True Atomic Operations**: Add/remove individual components with rollback safety
-- **Hierarchical Sheet Management**: Fixes blank main schematics automatically
-- **Production Integration**: Seamless integration with existing circuit-synth pipeline  
-- **S-Expression Safety**: Proper parsing with backup/restore on failure
-- **JSON Pipeline Integration**: Full compatibility with circuit-synth JSON format
+Optimized direct search (80% faster, zero LLM tokens):
 
-### Use Cases
+```python
+from circuit_synth.manufacturing.jlcpcb import fast_jlc_search, find_cheapest_jlc
 
-- **Incremental Updates**: Add components to existing designs without full regeneration
-- **Debug and Fix**: Resolve blank schematic issues (like ESP32-C6 project)
-- **External Integration**: Third-party tools can manipulate circuit-synth schematics
-- **Advanced Workflows**: Power users building custom automation
+# Search with filtering
+results = fast_jlc_search("STM32G4", min_stock=100, max_results=5)
 
-## FMEA and Quality Assurance
+# Find cheapest option
+cheapest = find_cheapest_jlc("0.1uF 0603", min_stock=1000)
+```
 
-Circuit-synth includes comprehensive failure analysis capabilities to ensure your designs are reliable:
+CLI usage:
+```bash
+jlc-fast search "USB-C connector" --min-stock 500
+jlc-fast cheapest "10k resistor" --min-stock 10000
+```
 
-### Automated FMEA Analysis
+### DigiKey Setup
 
+Configure DigiKey API for access to 8M+ components:
+
+```bash
+python -m circuit_synth.manufacturing.digikey.config_manager
+python -m circuit_synth.manufacturing.digikey.test_connection
+```
+
+## Library Sourcing
+
+Multi-source component library search with automatic fallback:
+
+```bash
+cs-library-setup                     # Show configuration status
+cs-setup-snapeda-api YOUR_KEY        # Optional: Enable SnapEDA API
+cs-setup-digikey-api KEY CLIENT_ID   # Optional: Enable DigiKey API
+```
+
+The `/find-symbol` and `/find-footprint` commands automatically search in order:
+1. Local KiCad installation
+2. DigiKey GitHub libraries (150+ curated libraries)
+3. SnapEDA API (millions of components)
+4. DigiKey API (supplier validation)
+
+Results show source: `[Local]`, `[DigiKey GitHub]`, `[SnapEDA]`, `[DigiKey API]`
+
+## SPICE Simulation
+
+```python
+circuit = my_circuit()
+sim = circuit.simulator()
+
+# DC analysis
+result = sim.operating_point()
+print(f"Output: {result.get_voltage('VOUT'):.3f}V")
+
+# AC analysis
+ac_result = sim.ac_analysis(1, 100000)
+```
+
+## FMEA Analysis
+
+Automated reliability analysis with comprehensive failure mode detection:
+
+```bash
+# Generate FMEA report
+uv run python -m circuit_synth.tools.quality_assurance.fmea_cli my_circuit.py
+
+# Specify output file and risk threshold
+uv run python -m circuit_synth.tools.quality_assurance.fmea_cli my_circuit.py -o report.pdf --threshold 150
+```
+
+Python API:
 ```python
 from circuit_synth.quality_assurance import EnhancedFMEAAnalyzer
 from circuit_synth.quality_assurance import ComprehensiveFMEAReportGenerator
 
-# Analyze your circuit for failures
 analyzer = EnhancedFMEAAnalyzer()
 circuit_context = {
-    'environment': 'industrial',    # Set operating environment
-    'safety_critical': True,        # Affects severity ratings
-    'production_volume': 'high'     # Influences detection ratings
+    'environment': 'industrial',       # Operating environment
+    'safety_critical': True,           # Affects severity ratings
+    'production_volume': 'high'        # Influences detection ratings
 }
 
-# Generate comprehensive PDF report (50+ pages)
+# Generate 50+ page PDF report
 generator = ComprehensiveFMEAReportGenerator("My Project")
 report_path = generator.generate_comprehensive_report(
     analysis_results,
@@ -370,131 +340,16 @@ report_path = generator.generate_comprehensive_report(
 )
 ```
 
-### What Gets Analyzed
-
-- **300+ Failure Modes**: Component failures, solder joints, environmental stress
-- **Physics-Based Models**: Arrhenius, Coffin-Manson, Black's equation
-- **IPC Class 3 Compliance**: High-reliability assembly standards
-- **Risk Assessment**: RPN (Risk Priority Number) calculations
-- **Mitigation Strategies**: Specific recommendations for each failure mode
-
-### Command Line FMEA
-
-```bash
-# Quick FMEA analysis
-uv run python -m circuit_synth.tools.quality_assurance.fmea_cli my_circuit.py
-
-# Specify output file
-uv run python -m circuit_synth.tools.quality_assurance.fmea_cli my_circuit.py -o FMEA_Report.pdf
-
-# Analyze with custom threshold
-uv run python -m circuit_synth.tools.quality_assurance.fmea_cli my_circuit.py --threshold 150
-```
-
-See [FMEA Guide](docs/FMEA_GUIDE.md) for detailed documentation.
-
-## Library Sourcing System
-
-Hybrid component discovery across multiple sources with automatic fallback:
-
-### Setup
-```bash
-cs-library-setup                    # Show configuration status
-cs-setup-snapeda-api YOUR_KEY       # Optional: SnapEDA API access  
-cs-setup-digikey-api KEY CLIENT_ID  # Optional: DigiKey API access
-```
-
-### Usage
-Enhanced `/find-symbol` and `/find-footprint` commands automatically search:
-1. **Local KiCad** (user installation)
-2. **DigiKey GitHub** (150 curated libraries, auto-converted)
-3. **SnapEDA API** (millions of components)
-4. **DigiKey API** (supplier validation)
-
-Results show source tags: `[Local]`, `[DigiKey GitHub]`, `[SnapEDA]`, `[DigiKey API]`
-
-## Fast JLCPCB Component Search
-
-The optimized search API provides direct JLCPCB component lookup without agent overhead:
-
-### Python API
-
-```python
-from circuit_synth.manufacturing.jlcpcb import fast_jlc_search, find_cheapest_jlc
-
-# Fast search with filtering
-results = fast_jlc_search("STM32G4", min_stock=100, max_results=5)
-for r in results:
-    print(f"{r.part_number}: {r.description} (${r.price}, stock: {r.stock})")
-
-# Find cheapest option
-cheapest = find_cheapest_jlc("0.1uF 0603", min_stock=1000)
-print(f"Cheapest: {cheapest.part_number} at ${cheapest.price}")
-```
-
-### CLI Usage
-
-```bash
-# Search components
-jlc-fast search "USB-C connector" --min-stock 500
-
-# Find cheapest with stock
-jlc-fast cheapest "10k resistor" --min-stock 10000
-
-# Performance benchmark
-jlc-fast benchmark
-```
-
-### Performance Improvements
-
-- **80% faster**: ~0.5s vs ~30s with agent-based search
-- **90% less tokens**: 0 LLM tokens vs ~500 per search
-- **Intelligent caching**: Avoid repeated API calls
-- **Batch operations**: Search multiple components efficiently
-
-## Project Structure
-
-```
-my_circuit_project/
-├── example_project/
-│   ├── circuit-synth/
-│   │   ├── main.py              # ESP32-C6 dev board (hierarchical)
-│   │   ├── power_supply.py      # 5V→3.3V regulation
-│   │   ├── usb.py               # USB-C with CC resistors
-│   │   ├── esp32c6.py           # ESP32-C6 microcontroller
-│   │   └── led_blinker.py       # Status LED control
-│   └── ESP32_C6_Dev_Board/      # Generated KiCad files
-│       ├── ESP32_C6_Dev_Board.kicad_pro
-│       ├── ESP32_C6_Dev_Board.kicad_sch
-│       ├── ESP32_C6_Dev_Board.kicad_pcb
-│       └── ESP32_C6_Dev_Board.net
-├── README.md                # Project guide
-├── CLAUDE.md                # AI assistant instructions
-└── pyproject.toml           # Project dependencies
-```
-
-
-## Why Circuit-Synth?
-
-| Traditional EE Workflow | With Circuit-Synth |
-|-------------------------|-------------------|
-| Manual component placement | `python example_project/circuit-synth/main.py` → Complete project |
-| Hunt through symbol libraries | Verified components with JLCPCB & DigiKey availability |
-| Visual net verification | Explicit Python connections |
-| GUI-based editing | Version-controlled Python files |
-| Copy-paste patterns | Reusable circuit functions |
-| Manual FMEA documentation | Automated 50+ page reliability analysis |
-
-## Resources
-
-- [Documentation](https://docs.circuit-synth.com)
-- [Examples](https://github.com/circuit-synth/examples)
-- [Contributing](CONTRIBUTING.md)
+Features:
+- 300+ failure modes (component failures, solder joints, environmental stress)
+- Physics-based reliability models (Arrhenius, Coffin-Manson, Black's equation)
+- IPC Class 3 compliance checking
+- Risk Priority Number (RPN) calculations
+- Specific mitigation strategies for each failure mode
 
 ## Development Setup
 
 ```bash
-# Clone and install
 git clone https://github.com/circuit-synth/circuit-synth.git
 cd circuit-synth
 uv sync
@@ -502,39 +357,14 @@ uv sync
 # Run tests
 uv run pytest
 
-# Optional: Register Claude Code agents
-uv run register-agents
-```
-
-
-For 6x performance improvement:
-
-```bash
-
-# Build modules
-
-# Test integration
-```
-
-## Testing
-
-```bash
-# Run comprehensive tests
-./tools/testing/run_full_regression_tests.py
-
-# Python tests only
-uv run pytest --cov=circuit_synth
-
-# Pre-release regression test
-./tools/testing/run_full_regression_tests.py
-
 # Code quality
 black src/ && isort src/ && flake8 src/ && mypy src/
 ```
 
-## KiCad Requirements
+## Requirements
 
-KiCad 8.0+ required:
+- Python 3.9+
+- KiCad 8.0+
 
 ```bash
 # macOS
@@ -542,175 +372,10 @@ brew install kicad
 
 # Linux
 sudo apt install kicad
-
-# Windows
-# Download from kicad.org
 ```
 
-## Troubleshooting
+## Resources
 
-Install the AI-powered KiCad plugin for direct Claude Code integration:
-
-```bash
-# Install KiCad plugins
-uv run cs-setup-kicad-plugins
-```
-
-**Usage:**
-- **PCB Editor**: Tools → External Plugins → "Circuit-Synth AI"  
-- **Schematic Editor**: Tools → Generate BOM → "Circuit-Synth AI"
-
-## 🛠️ Advanced Configuration
-
-### Environment Variables
-
-```bash
-# Optional performance settings
-export CIRCUIT_SYNTH_PARALLEL_PROCESSING=true
-
-# KiCad path override (if needed)
-export KICAD_SYMBOL_DIR="/custom/path/to/symbols"
-export KICAD_FOOTPRINT_DIR="/custom/path/to/footprints"
-```
-
-### Component Database Configuration
-
-```bash
-# JLCPCB API configuration (optional)
-export JLCPCB_API_KEY="your_api_key"
-export JLCPCB_CACHE_DURATION=3600  # Cache for 1 hour
-
-# DigiKey API configuration (optional, for component search)
-export DIGIKEY_CLIENT_ID="your_client_id"
-export DIGIKEY_CLIENT_SECRET="your_client_secret"
-# Or run: python -m circuit_synth.manufacturing.digikey.config_manager
-```
-
-## 🔍 Component Sourcing
-
-circuit-synth provides integrated access to multiple component distributors for real-time availability, pricing, and specifications.
-
-### Unified Multi-Source Search (Recommended)
-Search across all suppliers with one interface:
-```python
-from circuit_synth.manufacturing import find_parts
-
-# Search all suppliers
-results = find_parts("0.1uF 0603 X7R", sources="all")
-
-# Search specific supplier
-jlc_results = find_parts("STM32F407", sources="jlcpcb")
-dk_results = find_parts("LM358", sources="digikey")
-
-# Compare across suppliers
-comparison = find_parts("3.3V regulator", sources="all", compare=True)
-print(comparison)  # Shows price/availability comparison table
-
-# Filter by requirements
-high_stock = find_parts("10k resistor", min_stock=10000, max_price=0.10)
-```
-
-### JLCPCB Integration
-Best for PCB assembly and production:
-```python
-from circuit_synth.manufacturing.jlcpcb import search_jlc_components_web
-
-# Find components available for assembly
-results = search_jlc_components_web("STM32F407", max_results=10)
-```
-
-### DigiKey Integration  
-Best for prototyping and wide selection:
-```python
-from circuit_synth.manufacturing.digikey import search_digikey_components
-
-# Search DigiKey's 8M+ component catalog
-results = search_digikey_components("0.1uF 0603 X7R", max_results=10)
-
-# Get detailed pricing and alternatives
-from circuit_synth.manufacturing.digikey import DigiKeyComponentSearch
-searcher = DigiKeyComponentSearch()
-component = searcher.get_component_details("399-1096-1-ND")
-alternatives = searcher.find_alternatives(component, max_results=5)
-```
-
-### DigiKey Setup
-```bash
-# Interactive configuration
-python -m circuit_synth.manufacturing.digikey.config_manager
-
-# Test connection
-python -m circuit_synth.manufacturing.digikey.test_connection
-```
-
-See [docs/DIGIKEY_SETUP.md](docs/DIGIKEY_SETUP.md) for detailed setup instructions.
-
-### Multi-Source Strategy
-- **Prototyping**: Use DigiKey for fast delivery and no minimums
-- **Small Batch**: Compare JLCPCB vs DigiKey for best value
-- **Production**: Optimize with JLCPCB for integrated assembly
-- **Risk Mitigation**: Maintain alternatives from multiple sources
-
-## 🐛 Troubleshooting
-
-### Common Issues
-
-**KiCad Symbol/Footprint Not Found:**
-```bash
-# Verify KiCad installation
-kicad-cli version
-
-# Search for components (with Claude Code)
-/find-symbol STM32
-/find-footprint LQFP64
-```
-
-**Build Issues:**
-```bash
-# Clean rebuild
-```
-
-## Contributing
-
-See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup and guidelines.
-
-## 🏗️ Architecture Overview
-
-### Technical Stack
-- **Frontend**: Python 3.9+ with type hints
-- **KiCad Integration**: Direct file format support (.kicad_pro, .kicad_sch, .kicad_pcb)
-- **AI Integration**: Claude Code agents with specialized circuit design expertise
-
-### File Structure
-```
-circuit-synth/
-├── src/circuit_synth/           # Python package
-│   ├── core/                    # Core circuit representation
-│   ├── kicad/                   # KiCad file I/O
-│   ├── component_info/          # Component databases
-│   ├── manufacturing/           # JLCPCB, DigiKey, etc.
-│   └── simulation/              # SPICE integration
-├── example_project/             # Complete usage example
-├── tests/                       # Test suites
-└── tools/                       # Development and build tools (organized by category)
-```
-
-## 🤝 Contributing
-
-### Development Workflow
-1. **Fork repository** and create feature branch
-2. **Follow coding standards** (black, isort, mypy)
-3. **Add tests** for new functionality
-4. **Update documentation** as needed
-5. **Submit pull request** with clear description
-
-### Coding Standards
-- **Python**: Type hints, dataclasses, SOLID principles
-- **Documentation**: Clear docstrings and inline comments
-- **Testing**: Comprehensive test coverage for new features
-
-See [CONTRIBUTING.md](CONTRIBUTING.md) for detailed guidelines.
-
----
-
-**Professional PCB Design with Python**
+- [Documentation](https://docs.circuit-synth.com)
+- [Examples](https://github.com/circuit-synth/examples)
+- [Contributing](CONTRIBUTING.md)


### PR DESCRIPTION
## Summary
Major cleanup and improvement of the README.md file:

**Changes:**
- Reduced from 716 lines to ~350 lines (51% shorter)
- Removed marketing fluff, emojis, and repetition
- Removed internal-only atomic operations section

**Added:**
- Comprehensive "What is Code-Based Circuit Design?" section explaining the philosophy
- Traditional visual CAD vs code-based comparison
- Key benefits: version control, modularity, code review, automation, testing, AI-friendly
- When code-based design excels (parametric designs, repeated blocks, team collaboration)

**Improved:**
- Emphasized bi-directional KiCad workflow (import/export both ways)
- Highlighted extensive Claude Code integration (17 agents, 18 slash commands)
- Made clear circuit-synth works WITH existing KiCad workflows, not replacing them
- Better component search documentation
- More practical FMEA examples

**Result:**
A focused README that explains the "why" before the "how", making circuit-synth more accessible to new users while retaining all essential technical information.