### PR TITLE
🔖 Bump version to 0.8.37

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "circuit_synth"
-version = "0.8.36"
+version = "0.8.37"
 description = "Pythonic circuit design for production-ready KiCad projects"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -38,7 +38,7 @@ dependencies = [
     # Cache and performance dependencies
     "cachetools>=5.3.0",
     # KiCad schematic API integration
-    "kicad-sch-api>=0.1.1",
+    "kicad-sch-api>=0.2.2",
     "packaging>=21.0",
     # Additional data processing
     "sexpdata>=0.0.3",


### PR DESCRIPTION
## Summary
Updates circuit-synth to version 0.8.37 with kicad-sch-api v0.2.2 dependency.

## Changes
- **Version**: 0.8.36 → 0.8.37
- **Dependency**: kicad-sch-api >=0.1.1 → >=0.2.2

## Includes Fixes From kicad-sch-api v0.2.2
- Hierarchical schematic instance paths for proper component annotation
- Paper format compatibility fixes

## Related PRs
- kicad-sch-api#1 (merged) - Hierarchical fixes
- circuit-synth#146 (merged) - Integration updates
- circuit-synth#147 (merged) - Submodule update

🤖 Generated with [Claude Code](https://claude.com/claude-code)