### PR TITLE
🔧 Fix: Grid-aligned component placement (CRITICAL)

### DIFF
--- a/src/circuit_synth/kicad/schematic/text_flow_placement.py
+++ b/src/circuit_synth/kicad/schematic/text_flow_placement.py
@@ -12,6 +12,22 @@ from dataclasses import dataclass
 logger = logging.getLogger(__name__)
 
 
+def snap_to_grid(value: float, grid_size: float = 2.54) -> float:
+    """
+    Snap a coordinate value to the nearest grid point.
+
+    KiCad uses a 2.54mm (100mil) grid by default for professional schematics.
+
+    Args:
+        value: Coordinate value in mm
+        grid_size: Grid size in mm (default: 2.54mm = 100mil)
+
+    Returns:
+        Value snapped to nearest grid point
+    """
+    return round(value / grid_size) * grid_size
+
+
 @dataclass
 class SheetDef:
     """Sheet size definition."""
@@ -148,9 +164,13 @@ class TextFlowPlacer:
                 print(f"  ⚠️  Component {ref} overflows at y={bbox_y:.1f}mm (max={sheet.max_y:.1f}mm)")
                 return placements, False
 
-            # Calculate component center position
-            center_x = bbox_x + width / 2
-            center_y = bbox_y + height / 2
+            # Calculate component center position and snap to grid
+            center_x_raw = bbox_x + width / 2
+            center_y_raw = bbox_y + height / 2
+
+            # Snap to 2.54mm (100mil) grid for professional KiCad appearance
+            center_x = snap_to_grid(center_x_raw, 2.54)
+            center_y = snap_to_grid(center_y_raw, 2.54)
 
             placements.append((ref, center_x, center_y))
 


### PR DESCRIPTION
## Problem

Components were being placed at arbitrary floating-point positions instead of being aligned to KiCad's standard 2.54mm (100mil) grid. This made schematics look unprofessional and caused issues with manual adjustments in KiCad.

## Solution

Added `snap_to_grid()` function that snaps all component positions to the 2.54mm (100mil) grid standard used by KiCad.

## Changes

- Add `snap_to_grid()` helper function
- Apply grid snapping to all component center positions during placement
- Components now align perfectly to KiCad's professional grid

## Impact

### Before
```
R1: (26.4, 21.9)  - misaligned ❌
R2: (44.7, 21.9)  - misaligned ❌
```

### After
```
R1: (25.4, 22.86)  - perfectly aligned ✅ (10, 9) grid points
R2: (45.72, 22.86) - perfectly aligned ✅ (18, 9) grid points
```

## Why This Matters

KiCad uses a 2.54mm (100mil) grid by default for professional schematics. Grid alignment is critical for:

- ✅ Professional appearance
- ✅ Easy manual adjustments in KiCad
- ✅ Consistent with KiCad conventions
- ✅ Proper wire connection alignment
- ✅ Compatibility with manual layout work

Without grid alignment, users would need to manually snap every component to the grid after generation, defeating the purpose of automated layout.

## Testing

Verified with voltage divider test circuit:
```bash
cd docs/round-trip
uv run python test1_basic_divider.py
```

All component positions now snap to 2.54mm grid.

Grid verification:
```
✅ R1:  (25.40, 22.86) → (10.00, 9.00) grids
✅ R2:  (45.72, 22.86) → (18.00, 9.00) grids
```

## Files Changed

- `src/circuit_synth/kicad/schematic/text_flow_placement.py` - Added grid snapping

🤖 Generated with [Claude Code](https://claude.com/claude-code)