### PR TITLE
Fix text width ratio for accurate pin label bounding boxes

### DIFF
--- a/src/circuit_synth/kicad/sch_gen/symbol_geometry.py
+++ b/src/circuit_synth/kicad/sch_gen/symbol_geometry.py
@@ -21,10 +21,11 @@ class SymbolBoundingBoxCalculator:
     DEFAULT_PIN_LENGTH = 2.54  # 100 mils
     DEFAULT_PIN_NAME_OFFSET = 0.508  # 20 mils
     DEFAULT_PIN_NUMBER_SIZE = 1.27  # 50 mils
-    # Increased text width ratio to better match KiCad's actual rendering
-    # KiCad uses proportional fonts where character width varies
+    # Improved text width ratio to match KiCad's proportional font rendering
+    # KiCad uses proportional fonts where average character width is ~0.65x height
+    # This prevents label text from extending beyond calculated bounding boxes
     DEFAULT_PIN_TEXT_WIDTH_RATIO = (
-        1.0  # Width to height ratio for pin text
+        0.65  # Width to height ratio for pin text (proportional font average)
     )
 
     @classmethod


### PR DESCRIPTION
## Summary
Fixes #158 - Updates the pin text width ratio from 1.0 to 0.65 to accurately match KiCad's proportional font rendering.

## Problem
The previous ratio of 1.0 assumed monospaced fonts, causing calculated bounding boxes to be wider than actual rendered text. This led to:
- Pin labels extending beyond component boundaries
- Inaccurate collision detection
- Excessive spacing between components

## Solution
Changed `DEFAULT_PIN_TEXT_WIDTH_RATIO` from 1.0 to 0.65 in `symbol_geometry.py` to reflect KiCad's proportional font characteristics where average character width ≈ 0.65x height.

## Testing
- Manual verification with test circuits containing various component sizes
- Confirmed bounding boxes now accurately contain pin label text
- No overlap or excessive spacing observed

## Impact
- More accurate component placement
- Better collision detection
- Tighter, more professional schematic layouts

🤖 Generated with [Claude Code](https://claude.com/claude-code)