### PR TITLE
fix: Correct Text class parameters in annotation system (issue #238)

### DIFF
--- a/src/circuit_synth/kicad/sch_gen/schematic_writer.py
+++ b/src/circuit_synth/kicad/sch_gen/schematic_writer.py
@@ -1673,11 +1673,14 @@ class SchematicWriter:
             uuid = textbox.uuid
 
         # Create a Text object (we'll handle the box in S-expression generation)
+        # Note: Text class expects uuid, position, text, rotation, size
+        import uuid as uuid_module
         text_element = Text(
-            content=text,
+            uuid=uuid or str(uuid_module.uuid4()),
             position=Point(position[0], position[1]),
+            text=text,
+            rotation=rotation,
             size=text_size,
-            orientation=rotation,
         )
 
         # Store additional textbox properties for S-expression generation


### PR DESCRIPTION
## Summary

Fixes issue #238 where TextBox annotations were failing with error:
```
Text.__init__() got an unexpected keyword argument 'content'
```

## Problem

The annotation system in `schematic_writer.py` was calling the `Text` class constructor with incorrect parameter names:
- ❌ `content=text` → ✅ `text=text`
- ❌ `orientation=rotation` → ✅ `rotation=rotation`
- ❌ Missing required `uuid` parameter

The `kicad-sch-api` Text class signature is:
```python
Text(uuid: str, position: Point, text: str, rotation: float = 0.0, size: float = 1.27, ...)
```

## Solution

Updated the `_add_textbox_annotation()` method to use correct parameter names:

```python
text_element = Text(
    uuid=uuid or str(uuid_module.uuid4()),  # Added required uuid
    position=Point(position[0], position[1]),
    text=text,           # Changed from 'content'
    rotation=rotation,   # Changed from 'orientation'
    size=text_size,
)
```

## Testing

Tested with simple resistor circuit:
- ✅ No more annotation errors
- ✅ Circuit generates successfully
- ✅ Schematic opens in KiCad

## Impact

- Fixes annotation errors for all circuits with docstrings
- Enables proper TextBox annotations in schematics
- No breaking changes to API

Fixes #238

🤖 Generated with [Claude Code](https://claude.com/claude-code)