### PR TITLE
chore: Remove excessive debug logging from schematic generation

### DIFF
--- a/src/circuit_synth/kicad/sch_gen/main_generator.py
+++ b/src/circuit_synth/kicad/sch_gen/main_generator.py
@@ -422,14 +422,7 @@ class SchematicGenerator:
         self, json_file: str, draw_bounding_boxes: bool = False
     ):
         """Update existing project using synchronizer to preserve manual work"""
-        print("\n" + "="*80)
-        print("🔧 DEBUG: _update_existing_project() CALLED")
-        print("="*80)
         logger.info("🔄 Updating existing project while preserving your work...")
-        logger.info(f"   json_file: {json_file}")
-        logger.info(f"   project_dir: {self.project_dir}")
-        print(f"📁 json_file: {json_file}")
-        print(f"📁 project_dir: {self.project_dir}")
 
         # Import here to avoid circular dependencies
         logger.debug("Importing synchronizers...")
@@ -459,69 +452,34 @@ class SchematicGenerator:
 
         # Check if this is a hierarchical project
         # Note: sub_dict always includes the main circuit, so check if there's more than one
-        print("\n" + "="*80)
-        print("🔍 DEBUG: Determining project type")
-        print("="*80)
-        print(f"📊 sub_dict keys: {list(sub_dict.keys())}")
-        print(f"📊 sub_dict length: {len(sub_dict)}")
         has_subcircuits = len(sub_dict) > 1
-        print(f"📊 has_subcircuits = len(sub_dict) > 1 = {len(sub_dict)} > 1 = {has_subcircuits}")
-        print(f"📊 Project type: {'HIERARCHICAL' if has_subcircuits else 'FLAT'}")
-        print("="*80 + "\n")
-        logger.info(f"🔍 Project detection: sub_dict has {len(sub_dict)} circuits")
-        logger.info(f"   Circuit names: {list(sub_dict.keys())}")
-        logger.info(f"   has_subcircuits={has_subcircuits} (flat={not has_subcircuits})")
+        logger.debug(f"Project has {len(sub_dict)} circuits: {'hierarchical' if has_subcircuits else 'flat'}")
 
         if has_subcircuits:
             # Use hierarchical synchronizer for projects with subcircuits
-            print("\n" + "="*80)
-            print("🏗️ DEBUG: Creating HIERARCHICAL synchronizer")
-            print("="*80)
-            print(f"📍 project_path: {project_path}")
-            print(f"📍 Number of subcircuits: {len(sub_dict)}")
-            logger.debug(
-                f"Creating hierarchical synchronizer for project: {project_path}"
-            )
             logger.info(
                 f"Detected hierarchical project with {len(sub_dict)} subcircuits"
             )
             synchronizer = HierarchicalSynchronizer(
                 project_path=str(project_path), preserve_user_components=True
             )
-            print(f"✅ HierarchicalSynchronizer created: {type(synchronizer)}")
-            print("="*80 + "\n")
             # Show hierarchy info
             logger.info(synchronizer.get_hierarchy_info())
         else:
             # Use regular synchronizer for flat projects
-            print("\n" + "="*80)
-            print("🏗️ DEBUG: Creating FLAT (SyncAdapter) synchronizer")
-            print("="*80)
-            print(f"📍 project_path: {project_path}")
-            logger.debug(f"Creating synchronizer for flat project: {project_path}")
+            logger.debug(f"Creating synchronizer for flat project")
             synchronizer = SyncAdapter(
                 project_path=str(project_path), preserve_user_components=True
             )
-            print(f"✅ SyncAdapter created: {type(synchronizer)}")
-            print("="*80 + "\n")
 
         # Perform synchronization
-        print("\n" + "="*80)
-        print("🔄 DEBUG: Starting synchronization")
-        print("="*80)
-        print(f"📊 Synchronizer type: {type(synchronizer).__name__}")
-        print(f"📊 has_subcircuits: {has_subcircuits}")
         logger.debug("Starting synchronization...")
         if has_subcircuits:
             # Pass subcircuit dictionary for hierarchical sync
-            print("📞 Calling synchronizer.sync_with_circuit(top_circuit, sub_dict)")
             sync_report = synchronizer.sync_with_circuit(top_circuit, sub_dict)
         else:
-            print("📞 Calling synchronizer.sync_with_circuit(top_circuit)")
             sync_report = synchronizer.sync_with_circuit(top_circuit)
-        print(f"✅ Synchronization completed!")
-        print(f"📊 Sync report keys: {list(sync_report.keys()) if isinstance(sync_report, dict) else 'N/A'}")
-        print("="*80 + "\n")
+        logger.info("✅ Synchronization completed!")
 
         # Add bounding boxes if requested
         if draw_bounding_boxes:
@@ -688,11 +646,6 @@ class SchematicGenerator:
 
         if project_exists and not force_regenerate:
             # Auto-switch to update mode
-            print("\n" + "="*80)
-            print("🔄 DEBUG: generate_project() switching to UPDATE MODE")
-            print("="*80)
-            print(f"📁 Project exists: {project_exists}")
-            print(f"🚫 force_regenerate: {force_regenerate}")
             logger.info(f"Existing KiCad project detected at: {self.project_dir}")
             logger.info(
                 "🔄 Automatically switching to update mode to preserve your work"
@@ -702,14 +655,9 @@ class SchematicGenerator:
             )
 
             try:
-                print("📞 Calling _update_existing_project()...")
                 result = self._update_existing_project(json_file, draw_bounding_boxes)
-                print(f"✅ _update_existing_project() returned successfully!")
                 return result
             except Exception as e:
-                print("\n" + "="*80)
-                print("❌ DEBUG: EXCEPTION CAUGHT in generate_project()")
-                print("="*80)
                 print(f"🔥 Exception type: {type(e).__name__}")
                 print(f"🔥 Exception message: {e}")
                 import traceback
@@ -806,7 +754,6 @@ class SchematicGenerator:
         logger.info(f"  Main circuit name: {top_name}")
         logger.info(f"  Hierarchical path: {hierarchical_path}")
 
-        print(f"🚨 MAIN_GEN DEBUG: About to create SchematicWriter with draw_bounding_boxes={draw_bounding_boxes}")
         main_writer = SchematicWriter(
             sub_dict[top_name],
             sub_dict,
@@ -818,9 +765,7 @@ class SchematicGenerator:
             draw_bounding_boxes=draw_bounding_boxes,  # Pass bounding box flag
             uuid=root_uuid,  # Pass the root UUID to ensure consistency
         )
-        print(f"🚨 MAIN_GEN DEBUG: SchematicWriter created, calling generate_s_expr()")
         main_sch_expr = main_writer.generate_s_expr()
-        print(f"🚨 MAIN_GEN DEBUG: generate_s_expr() returned")
         sheet_uuids[top_name] = main_writer.uuid_top
         sheet_writers[top_name] = main_writer  # Store main writer for reference
 

--- a/src/circuit_synth/kicad/schematic/synchronizer.py
+++ b/src/circuit_synth/kicad/schematic/synchronizer.py
@@ -485,8 +485,7 @@ class APISynchronizer:
 
     def _save_schematic(self):
         """Save the modified schematic using kicad-sch-api's native save."""
-        print("💾 _save_schematic() called")
-        logger.info("_save_schematic() called")
+        logger.debug("Saving schematic")
 
         # WORKAROUND: kicad-sch-api bug where WireCollection doesn't sync to _data["wires"]
         # Manually sync wires from collection to _data before saving
@@ -494,10 +493,8 @@ class APISynchronizer:
 
         # Use kicad-sch-api's built-in save method which handles all S-expression formatting
         # and lib_symbols automatically. This preserves format and includes wires/labels.
-        print(f"💾 Calling schematic.save({self.schematic_path})")
         self.schematic.save(str(self.schematic_path), preserve_format=True)
-        print(f"✅ Schematic saved successfully")
-        logger.info(f"Saved schematic to {self.schematic_path}")
+        logger.info(f"✅ Schematic saved successfully")
 
     def _sync_wires_to_data(self):
         """
@@ -507,37 +504,28 @@ class APISynchronizer:
         but doesn't update _data["wires"], so when saving, wires are lost. This method
         manually syncs the wire collection to _data before saving.
         """
-        print("🔧 _sync_wires_to_data() called")
-        logger.info("🔧 _sync_wires_to_data() called")
-
         if not hasattr(self.schematic, '_data'):
-            print("⚠️  Schematic has no _data attribute")
             logger.warning("Schematic has no _data attribute")
             return
 
         if not hasattr(self.schematic, 'wires'):
-            print("⚠️  Schematic has no wires attribute")
             logger.warning("Schematic has no wires attribute")
             return
 
         # Get all wires from the wire collection
         try:
             wires_list = list(self.schematic.wires)
-            print(f"📊 Retrieved {len(wires_list)} wires from collection")
-            logger.info(f"Retrieved {len(wires_list)} wires from collection")
+            logger.debug(f"Retrieved {len(wires_list)} wires from collection")
         except (TypeError, AttributeError) as e:
-            print(f"⚠️  Could not access wires collection: {e}")
             logger.warning(f"Could not access wires collection: {e}")
             return
 
         if not wires_list:
             # No wires to sync
-            print("📊 No wires to sync (empty list)")
-            logger.info("No wires to sync (empty list)")
+            logger.debug("No wires to sync (empty list)")
             return
 
-        print(f"🔄 Syncing {len(wires_list)} wires from collection to _data")
-        logger.info(f"🔄 Syncing {len(wires_list)} wires from collection to _data")
+        logger.debug(f"Syncing {len(wires_list)} wires to _data")
 
         # Convert Wire objects to dictionaries for _data
         wire_dicts = []


### PR DESCRIPTION
## Summary

Significantly reduces console noise by removing excessive debug print statements while preserving essential user-facing information.

## Problem

Console output was cluttered with verbose debug information:
- Multiple separator lines (==========)
- Debug prints for every internal step
- Redundant status messages
- Unnecessary emoji-heavy output

This made it hard to see actual issues and status.

## Solution

Removed excessive debug prints:
- ❌ DEBUG separator lines
- ❌ Project type detection debug logs
- ❌ Synchronizer creation debug logs  
- ❌ Synchronization start/end debug logs
- ❌ SchematicWriter creation debug logs
- ❌ Wire sync verbose logging
- ❌ Schematic save verbose logging

Kept essential logging:
- ✅ Version information at startup
- ✅ Info-level status messages
- ✅ Warning/error logs for issues
- ✅ User-facing completion messages

## Before/After

**Before:**
```
================================================================================
🔧 DEBUG: _update_existing_project() CALLED  
================================================================================
📁 json_file: /tmp/tmpxxx.json
📁 project_dir: /path/to/project

================================================================================
🔍 DEBUG: Determining project type
================================================================================
📊 sub_dict keys: ['Simple_Resistor']
📊 sub_dict length: 1
📊 has_subcircuits = len(sub_dict) > 1 = 1 > 1 = False
📊 Project type: FLAT
================================================================================
...
```

**After:**
```
🔄 Updating existing project while preserving your work...
✅ Synchronization completed!
✅ Schematic saved successfully
```

## Impact

- ✅ Much cleaner console output
- ✅ Easier to spot actual issues
- ✅ Faster to read logs
- ✅ No breaking changes
- ✅ Debug logs still available at debug level

🤖 Generated with [Claude Code](https://claude.com/claude-code)