### PR TITLE
fix: Add missing imports for CourtyardCollisionDetector in spiral_placement_v2

### DIFF
--- a/src/circuit_synth/pcb/placement/spiral_placement_v2.py
+++ b/src/circuit_synth/pcb/placement/spiral_placement_v2.py
@@ -8,11 +8,10 @@ Uses actual courtyard geometry for accurate collision detection.
 
 import math
 from dataclasses import dataclass
-
-# Using simplified placement - removed complex courtyard collision for now
 from typing import Dict, List, NamedTuple, Optional, Set, Tuple
 
 from circuit_synth.pcb.types import Footprint, Point
+from .courtyard_collision_improved import CourtyardCollisionDetector, Polygon
 
 
 class BoundingBox(NamedTuple):


### PR DESCRIPTION
## Summary

Fixes missing imports in `SpiralPlacementAlgorithmV2` class that were causing `NameError` at runtime when the spiral placement algorithm was invoked for PCB component placement.

## Problem

The `spiral_placement_v2.py` module instantiated `CourtyardCollisionDetector` and used `Polygon` class without importing them, causing:
```
NameError: name 'CourtyardCollisionDetector' is not defined
```

This error occurred whenever circuit-synth attempted to generate a PCB using the spiral placement algorithm.

## Solution

Added import statement to include the collision detector and polygon classes from the improved courtyard collision detection module:

```python
from .courtyard_collision_improved import CourtyardCollisionDetector, Polygon
```

### Why `courtyard_collision_improved.py`?

- ✅ Better KiCad coordinate system handling (accounts for inverted Y-axis)
- ✅ Polygon caching for improved performance
- ✅ More robust geometry calculations
- ✅ True polygon-polygon intersection using SAT (Separating Axis Theorem)

## Testing

- ✅ Circuit generation now completes without errors
- ✅ Component placement uses proper collision detection
- ✅ All downstream functionality works correctly

## Related Issues

Fixes NameError when placing components with spiral placement algorithm