### PR TITLE
fix: Correct parameter name mismatch in kicad_to_python_sync.py main() (#250)

### DIFF
--- a/src/circuit_synth/tools/kicad_integration/kicad_to_python_sync.py
+++ b/src/circuit_synth/tools/kicad_integration/kicad_to_python_sync.py
@@ -584,7 +584,7 @@ def main():
 
     # Create syncer and run
     syncer = KiCadToPythonSyncer(
-        kicad_project=str(kicad_project),
+        kicad_project_or_json=str(kicad_project),
         python_file=str(python_file),
         preview_only=False,  # Always apply changes
         create_backup=args.backup,


### PR DESCRIPTION
## Summary

Fixes #250 - Parameter name mismatch preventing the KiCad → Python sync CLI tool from running.

## Problem

The `KiCadToPythonSyncer.__init__()` constructor expects parameter `kicad_project_or_json`, but `main()` was calling it with `kicad_project`, causing:

```
TypeError: KiCadToPythonSyncer.__init__() got an unexpected keyword argument 'kicad_project'
```

## Changes

**File:** `src/circuit_synth/tools/kicad_integration/kicad_to_python_sync.py`

- **Line 587:** Changed `kicad_project=` → `kicad_project_or_json=`

## Testing

✅ All unit tests pass (10/10):
```bash
uv run pytest tests/unit/test_kicad_to_python_syncer_refactored.py -v
```

## Impact

- **Before:** KiCad → Python sync CLI tool was completely broken
- **After:** CLI tool works as expected

## Test Plan

- [x] Unit tests pass
- [x] Parameter name matches constructor signature
- [x] Single-line fix, no side effects

🤖 Generated with [Claude Code](https://claude.com/claude-code)