### PR TITLE
fix: AST-based multi-line Component/Net detection

### DIFF
--- a/src/circuit_synth/tools/utilities/comment_extractor.py
+++ b/src/circuit_synth/tools/utilities/comment_extractor.py
@@ -9,6 +9,7 @@ across KiCad ↔ Python synchronization cycles.
 
 import ast
 import logging
+import subprocess
 import tokenize
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
@@ -23,8 +24,35 @@ class CommentExtractor:
         """Initialize the comment extractor."""
         pass
 
+    def _format_code_with_black(self, code: str, line_length: int = 88) -> str:
+        """
+        Format Python code using Black formatter.
+
+        Args:
+            code: Python code to format
+            line_length: Maximum line length (default 88, use 200+ to force single-line)
+
+        Returns:
+            Formatted code, or original code if Black fails
+        """
+        try:
+            import black
+
+            # Format the code using Black
+            mode = black.Mode(
+                line_length=line_length,
+                string_normalization=True,
+                is_pyi=False,
+            )
+            formatted = black.format_str(code, mode=mode)
+            logger.debug(f"Successfully formatted code with Black (line_length={line_length})")
+            return formatted
+        except Exception as e:
+            logger.warning(f"Failed to format code with Black: {e}, using original code")
+            return code
+
     def extract_comments_from_function(
-        self, file_path: Path, function_name: str = "main"
+        self, file_path: Path, function_name: str = "main", content: Optional[str] = None
     ) -> Dict[int, List[str]]:
         """
         Extract all user-added content from a specific function.
@@ -35,25 +63,29 @@ class CommentExtractor:
         Args:
             file_path: Path to Python file
             function_name: Name of function to extract content from
+            content: Optional pre-formatted content to use instead of reading file
 
         Returns:
             Dictionary mapping line offset (relative to function start) to list of content lines
             Example: {0: ["# Comment"], 2: ['docstring content']}
         """
-        if not file_path.exists():
+        if content is None and not file_path.exists():
             logger.warning(f"File not found: {file_path}")
             return {}
 
         try:
             # Parse AST to find function boundaries
-            with open(file_path, "r") as f:
-                lines = f.readlines()
+            if content is not None:
+                lines = content.splitlines(keepends=True)
+            else:
+                with open(file_path, "r") as f:
+                    lines = f.readlines()
 
             tree = ast.parse("".join(lines))
             function_start_line = self._find_function_start_line(tree, function_name)
-            function_end_line = self._find_function_end_line(
-                tree, function_name, file_path
-            )
+            # Pass content if available, otherwise reads from file
+            lines_str = "".join(lines) if content else None
+            function_end_line = self._find_function_end_line(tree, function_name, file_path, content=lines_str)
 
             if function_start_line is None:
                 logger.warning(f"Function '{function_name}' not found in {file_path}")
@@ -77,9 +109,7 @@ class CommentExtractor:
             for line_num in range(content_start_line, function_end_line + 1):
                 line_idx = line_num - 1  # Convert to 0-indexed
                 if line_idx < len(lines):
-                    line = lines[
-                        line_idx
-                    ].rstrip()  # Keep indentation, remove trailing whitespace
+                    line = lines[line_idx].rstrip()  # Keep indentation, remove trailing whitespace
                     # Include ALL lines - blank lines preserve spacing
                     offset = line_num - content_start_line
                     if offset not in content_map:
@@ -131,7 +161,7 @@ class CommentExtractor:
         return None
 
     def _find_function_end_line(
-        self, tree: ast.AST, function_name: str, file_path: Path
+        self, tree: ast.AST, function_name: str, file_path: Path, content: Optional[str] = None
     ) -> Optional[int]:
         """
         Find the ending line number of a function by analyzing indentation.
@@ -143,6 +173,7 @@ class CommentExtractor:
             tree: Parsed AST tree
             function_name: Name of function to find
             file_path: Path to the source file for indentation analysis
+            content: Optional pre-formatted content to use instead of reading file
 
         Returns:
             Line number (1-indexed) of last line with function-level indentation
@@ -160,8 +191,11 @@ class CommentExtractor:
             return None
 
         # Now scan the file to find actual function end by indentation
-        with open(file_path, "r") as f:
-            lines = f.readlines()
+        if content is not None:
+            lines = content.splitlines(keepends=True)
+        else:
+            with open(file_path, "r") as f:
+                lines = f.readlines()
 
         # Find the def line and determine function indentation
         def_line_idx = None
@@ -201,10 +235,7 @@ class CommentExtractor:
         return last_function_line
 
     def _extract_comments_with_tokenize(
-        self,
-        file_path: Path,
-        function_start_line: int,
-        function_end_line: Optional[int] = None,
+        self, file_path: Path, function_start_line: int, function_end_line: Optional[int] = None
     ) -> Dict[int, List[str]]:
         """
         Extract comments using the tokenize module.
@@ -231,10 +262,7 @@ class CommentExtractor:
                         # Only include comments within function bounds
                         if line_num < function_start_line:
                             continue
-                        if (
-                            function_end_line is not None
-                            and line_num > function_end_line
-                        ):
+                        if function_end_line is not None and line_num > function_end_line:
                             continue
 
                         # Calculate offset relative to function start
@@ -279,7 +307,7 @@ class CommentExtractor:
         # Count trailing blanks
         trailing_blank_count = 0
         for line in reversed(all_content):
-            if line.strip() == "":
+            if line.strip() == '':
                 trailing_blank_count += 1
             else:
                 break
@@ -294,7 +322,7 @@ class CommentExtractor:
         generated_lines_copy = list(generated_lines)  # Don't modify original
         trailing_gen_blank_count = 0
         for line in reversed(generated_lines_copy):
-            if line.strip() == "":
+            if line.strip() == '':
                 trailing_gen_blank_count += 1
             else:
                 break
@@ -324,9 +352,7 @@ class CommentExtractor:
         """
         return line[: len(line) - len(line.lstrip())]
 
-    def extract_after_function_content(
-        self, file_path: Path, function_name: str = "main"
-    ) -> List[str]:
+    def extract_after_function_content(self, file_path: Path, function_name: str = "main") -> List[str]:
         """
         Extract content that appears AFTER the function ends but BEFORE if __name__.
 
@@ -348,9 +374,7 @@ class CommentExtractor:
                 lines = f.readlines()
 
             tree = ast.parse("".join(lines))
-            function_end_line = self._find_function_end_line(
-                tree, function_name, file_path
-            )
+            function_end_line = self._find_function_end_line(tree, function_name, file_path)
 
             if function_end_line is None:
                 return []
@@ -375,9 +399,9 @@ class CommentExtractor:
                     after_function_content.append(line)
 
             # Strip leading and trailing blank lines
-            while after_function_content and after_function_content[0].strip() == "":
+            while after_function_content and after_function_content[0].strip() == '':
                 after_function_content.pop(0)
-            while after_function_content and after_function_content[-1].strip() == "":
+            while after_function_content and after_function_content[-1].strip() == '':
                 after_function_content.pop()
 
             return after_function_content
@@ -411,16 +435,10 @@ class CommentExtractor:
                     # Check if it has @circuit decorator
                     for decorator in node.decorator_list:
                         # Handle both @circuit and @circuit(...)
-                        if (
-                            isinstance(decorator, ast.Name)
-                            and decorator.id == "circuit"
-                        ):
+                        if isinstance(decorator, ast.Name) and decorator.id == "circuit":
                             return node.name
                         elif isinstance(decorator, ast.Call):
-                            if (
-                                isinstance(decorator.func, ast.Name)
-                                and decorator.func.id == "circuit"
-                            ):
+                            if isinstance(decorator.func, ast.Name) and decorator.func.id == "circuit":
                                 return node.name
 
             # Fallback: if no @circuit found, look for any function
@@ -455,37 +473,40 @@ class CommentExtractor:
             Merged code with user content preserved and generated code updated
         """
         if not existing_file.exists():
-            # No existing file, return generated template as-is
-            return generated_template
+            # No existing file, return generated template formatted
+            return self._format_code_with_black(generated_template)
 
         # Auto-detect function name if not provided
         if function_name is None:
             function_name = self.find_circuit_function_name(existing_file)
             if function_name is None:
-                logger.warning(
-                    "Could not find circuit function, using 'main' as fallback"
-                )
+                logger.warning("Could not find circuit function, using 'main' as fallback")
                 function_name = "main"
             else:
                 logger.info(f"Auto-detected circuit function: {function_name}")
 
         try:
-            # Read existing file
+            # Read existing file and normalize formatting with Black
             with open(existing_file, "r") as f:
-                existing_lines = f.readlines()
+                existing_content_raw = f.read()
+
+            # Format existing file with Black using VERY LONG line length (200)
+            # This forces multi-line Component() calls to be single-line,
+            # making them easier to detect and remove during merge
+            existing_content = self._format_code_with_black(existing_content_raw, line_length=200)
+            existing_lines = existing_content.split("\n")
+            # Add back newlines for compatibility
+            existing_lines = [line + "\n" if i < len(existing_lines) - 1 else line
+                            for i, line in enumerate(existing_lines)]
 
             # Parse both existing and generated code
-            existing_content = "".join(existing_lines)
             generated_lines = generated_template.split("\n")
 
             # Find function boundaries in EXISTING file
             existing_tree = ast.parse(existing_content)
-            existing_func_start = self._find_function_start_line(
-                existing_tree, function_name
-            )
-            existing_func_end = self._find_function_end_line(
-                existing_tree, function_name, existing_file
-            )
+            existing_func_start = self._find_function_start_line(existing_tree, function_name)
+            # IMPORTANT: Pass formatted content so indentation analysis uses formatted version
+            existing_func_end = self._find_function_end_line(existing_tree, function_name, existing_file, content=existing_content)
 
             if existing_func_start is None:
                 # Function doesn't exist in old file, return template
@@ -493,21 +514,15 @@ class CommentExtractor:
 
             # Find function body content in GENERATED template (the new component code)
             # Try the detected function name first, then try "main" as fallback
-            generated_func_start_idx = self._find_function_start_index(
-                generated_lines, function_name
-            )
+            generated_func_start_idx = self._find_function_start_index(generated_lines, function_name)
             if generated_func_start_idx is None and function_name != "main":
                 # Function not found, try "main" (the template default)
-                logger.info(
-                    f"Function '{function_name}' not in generated code, trying 'main' fallback"
-                )
-                generated_func_start_idx = self._find_function_start_index(
-                    generated_lines, "main"
-                )
+                logger.info(f"Function '{function_name}' not in generated code, trying 'main' fallback")
+                generated_func_start_idx = self._find_function_start_index(generated_lines, "main")
 
             if generated_func_start_idx is None:
                 # Can't find any function in generated code, return existing
-                logger.warning(f"Could not find function in generated code")
+                logger.warning(f"Could not find function in generated code (searched for '{function_name}')")
                 return existing_content
 
             # Extract the NEW generated component code (everything after docstring in generated file)
@@ -515,14 +530,13 @@ class CommentExtractor:
             for i in range(generated_func_start_idx, len(generated_lines)):
                 line = generated_lines[i]
                 # Stop at "# Generate the circuit" or end of function indicators
-                if line.strip().startswith(
-                    "# Generate the circuit"
-                ) or line.strip().startswith("if __name__"):
+                if line.strip().startswith("# Generate the circuit") or \
+                   line.strip().startswith("if __name__"):
                     break
                 generated_func_body.append(line)
 
             # Strip trailing blank lines from generated body
-            while generated_func_body and generated_func_body[-1].strip() == "":
+            while generated_func_body and generated_func_body[-1].strip() == '':
                 generated_func_body.pop()
 
             # Now build the result: existing file with function body replaced
@@ -532,14 +546,15 @@ class CommentExtractor:
             for i in range(existing_func_start):
                 # Preserve line as-is but remove trailing newline
                 line = existing_lines[i]
-                if line.endswith("\n"):
+                if line.endswith('\n'):
                     line = line[:-1]
                 result_lines.append(line.rstrip())
 
             # Part 2: User content from INSIDE old function + NEW generated code
             # Extract user comments from inside the existing function
+            # IMPORTANT: Pass the formatted content so we process the single-line version
             user_comments_map = self.extract_comments_from_function(
-                existing_file, function_name
+                existing_file, function_name, content=existing_content
             )
 
             # Filter out generated patterns and standalone 'pass' statements
@@ -547,42 +562,63 @@ class CommentExtractor:
             if user_comments_map and generated_func_body:
                 # Check if any generated line has actual component code (not just whitespace/comments)
                 has_real_code = any(
-                    line.strip()
-                    and not line.strip().startswith("#")
-                    and not line.strip().startswith('"""')
-                    and not line.strip().startswith("'''")
+                    line.strip() and
+                    not line.strip().startswith('#') and
+                    not line.strip().startswith('"""') and
+                    not line.strip().startswith("'''")
                     for line in generated_func_body
                 )
 
                 if has_real_code:
                     # Known generated comment patterns that should not be preserved
                     generated_patterns = [
-                        "pass",  # Standalone pass statement
-                        "# Create components",  # Generated section marker
-                        "# Create nets",  # Generated section marker
-                        "# Create subcircuits",  # Generated section marker
+                        'pass',  # Standalone pass statement
+                        '# Create components',  # Generated section marker
+                        '# Create nets',  # Generated section marker
+                        '# Create subcircuits',  # Generated section marker
                     ]
 
                     # Remove generated patterns and component code lines
+                    # Parse the content to identify component assignments using AST
+                    component_line_ranges = set()
+                    try:
+                        # Parse the formatted existing content to find Component/Net assignments
+                        tree = ast.parse(existing_content)
+                        for node in ast.walk(tree):
+                            if isinstance(node, ast.Assign):
+                                # Check if RHS is a Call to Component or Net
+                                if isinstance(node.value, ast.Call):
+                                    if isinstance(node.value.func, ast.Name):
+                                        if node.value.func.id in ('Component', 'Net'):
+                                            # Add all lines from this assignment to the exclusion set
+                                            # Convert to 0-indexed and account for function start
+                                            start_line = node.lineno - 1  # AST is 1-indexed
+                                            end_line = node.end_lineno - 1 if node.end_lineno else start_line
+                                            for line_num in range(start_line, end_line + 1):
+                                                component_line_ranges.add(line_num)
+                    except Exception as e:
+                        logger.warning(f"Failed to parse AST for component detection: {e}")
+
                     filtered_comments = {}
                     for offset, lines in user_comments_map.items():
                         filtered_lines = []
-                        for line in lines:
+                        for i, line in enumerate(lines):
                             stripped = line.strip()
                             # Skip if it's a generated pattern
                             if stripped in generated_patterns:
                                 continue
-                            # Skip if it looks like generated component code
-                            # (starts with variable assignment for common component patterns)
-                            if stripped and not stripped.startswith("#"):
-                                # Check if it's a component assignment (e.g., "r1 = Component(...)")
-                                if "= Component(" in stripped or "= Net(" in stripped:
-                                    continue
+
+                            # Calculate absolute line number in the file
+                            # offset is relative to function start, so add existing_func_start
+                            abs_line_num = existing_func_start + offset + i
+
+                            # Skip if this line is part of a Component/Net assignment
+                            if abs_line_num in component_line_ranges:
+                                continue
+
                             filtered_lines.append(line)
 
-                        if (
-                            filtered_lines
-                        ):  # Only keep if there's content after filtering
+                        if filtered_lines:  # Only keep if there's content after filtering
                             filtered_comments[offset] = filtered_lines
 
                     # Now remove leading blank-only entries, but keep blank lines between content
@@ -593,9 +629,7 @@ class CommentExtractor:
                         last_non_blank = None
 
                         for offset in sorted_offsets:
-                            has_content = any(
-                                line.strip() for line in filtered_comments[offset]
-                            )
+                            has_content = any(line.strip() for line in filtered_comments[offset])
                             if has_content:
                                 if first_non_blank is None:
                                     first_non_blank = offset
@@ -617,27 +651,27 @@ class CommentExtractor:
             # Merge: user comments first, then generated code
             if user_comments_map:
                 # Reinsert user comments with generated code
-                merged_body = self.reinsert_comments(
-                    generated_func_body, user_comments_map
-                )
+                merged_body = self.reinsert_comments(generated_func_body, user_comments_map)
                 result_lines.extend(merged_body)
             else:
                 # No user comments, just use generated code
                 result_lines.extend(generated_func_body)
 
+
             # Part 3: Everything AFTER the function body (preserve user content after function)
             # existing_func_end is 1-indexed, so existing_lines[existing_func_end] is the line AFTER function end
-            if existing_func_end is not None and existing_func_end < len(
-                existing_lines
-            ):
+            if existing_func_end is not None and existing_func_end < len(existing_lines):
+                after_lines_count = len(existing_lines) - existing_func_end
                 for i in range(existing_func_end, len(existing_lines)):
                     # Preserve line as-is but remove trailing newline
                     line = existing_lines[i]
-                    if line.endswith("\n"):
+                    if line.endswith('\n'):
                         line = line[:-1]
                     result_lines.append(line.rstrip())
 
-            return "\n".join(result_lines)
+            # Format the final result with Black before returning
+            merged_code = "\n".join(result_lines)
+            return self._format_code_with_black(merged_code)
 
         except Exception as e:
             logger.error(f"Failed to merge preserving user content: {e}")
@@ -667,9 +701,7 @@ class CommentExtractor:
         comments_map = self.extract_comments_from_function(existing_file, function_name)
 
         # Extract content after function (between function and if __name__)
-        after_function_content = self.extract_after_function_content(
-            existing_file, function_name
-        )
+        after_function_content = self.extract_after_function_content(existing_file, function_name)
 
         if not comments_map and not after_function_content:
             return generated_code
@@ -698,26 +730,21 @@ class CommentExtractor:
             # Find the "# Generate the circuit" or "if __name__" line
             insert_idx = None
             for i, line in enumerate(result_lines):
-                if line.strip().startswith(
-                    "# Generate the circuit"
-                ) or line.strip().startswith("if __name__"):
+                if line.strip().startswith("# Generate the circuit") or \
+                   line.strip().startswith("if __name__"):
                     insert_idx = i
                     break
 
             if insert_idx is not None:
                 # Insert after-function content before the boilerplate
-                result_lines = (
-                    result_lines[:insert_idx]
-                    + [""]
-                    + after_function_content
-                    + [""]
-                    + result_lines[insert_idx:]
-                )
+                result_lines = result_lines[:insert_idx] + [''] + after_function_content + [''] + result_lines[insert_idx:]
             else:
                 # No boilerplate found, append at end
-                result_lines.extend([""] + after_function_content)
+                result_lines.extend([''] + after_function_content)
 
-        return "\n".join(result_lines)
+        # Format the final result with Black before returning
+        merged_code = "\n".join(result_lines)
+        return self._format_code_with_black(merged_code)
 
     def _find_function_start_index(
         self, lines: List[str], function_name: str


### PR DESCRIPTION
## Summary

Fixes critical bug where multi-line component definitions would leave orphaned parameter lines during KiCad ↔ Python synchronization.

## Problem

When users formatted components as multi-line for readability:
```python
r1 = Component(
    symbol="Device:R",
    ref="R1", 
    value="10k",
    footprint="Resistor_SMD:R_0603_1608Metric",
)
```

The line-by-line string matching (`'= Component(' in line`) only detected the first line, leaving orphaned parameter lines that were incorrectly preserved as "user content":

```python
def circuit():
    # User comment
        symbol="Device:R",    # ❌ Orphaned - r1 = Component( was removed
        ref="R1",
        value="10k",
        ...
    )
    # New components added below...
```

## Solution

**AST-based component detection** instead of fragile string matching:

1. Parse existing code with Python's AST  
2. Find all `Component()` and `Net()` assignments using AST nodes
3. Track complete line ranges (start to end) for each assignment
4. Exclude entire ranges when filtering user content

This works regardless of formatting style (single-line or multi-line).

## Additional Improvements

- **Black formatter integration:** Consistent output formatting
- **Fixed `_find_function_end_line()`:** Now uses formatted content instead of reading stale data from disk
- **Added `content` parameter:** Better control over content source in `extract_comments_from_function()` and `_find_function_end_line()`

## Testing

✅ Tested with mixed single-line and multi-line components:
- Multi-line components properly detected and removed
- User comments correctly preserved  
- No orphaned parameter lines
- Clean Black-formatted output
- Works with any code formatting style

## Files Changed

- `src/circuit_synth/tools/utilities/comment_extractor.py` (+140, -113 lines)
  - Added `_format_code_with_black()` method
  - Modified `extract_comments_from_function()` to accept optional content
  - Modified `_find_function_end_line()` to accept optional content
  - Replaced string matching with AST-based detection in filtering logic

## Example

**Before (broken):**
```python
def circuit():
    # My comment
        symbol="Device:R",    # Orphaned!
        ref="R1",
    )
    r1 = Component(...)      # Duplicate!
```

**After (fixed):**
```python  
def circuit():
    # My comment
    r1 = Component(
        symbol="Device:R",
        ref="R1",
        value="10k",
        footprint="Resistor_SMD:R_0603_1608Metric",
    )
```

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>