### PR TITLE
feat: Document automatic manufacturing file generation in cs-new-project

### DIFF
--- a/src/circuit_synth/tools/project_management/new_project.py
+++ b/src/circuit_synth/tools/project_management/new_project.py
@@ -995,6 +995,11 @@ def main(
     )
     success_text += Text(f"\n📖 Documentation: See README.md")
 
+    if config.has_circuits():
+        success_text += Text(
+            f"\n📦 Manufacturing: Templates auto-generate BOM, PDF, and Gerbers"
+        )
+
     if config.include_agents:
         agents_count = len(list((project_path / ".claude" / "agents").rglob("*.md")))
         commands_count = len(

--- a/src/circuit_synth/tools/project_management/template_manager.py
+++ b/src/circuit_synth/tools/project_management/template_manager.py
@@ -186,6 +186,28 @@ if __name__ == '__main__':
     )
 ```
 
+### Manufacturing File Generation
+
+All circuit templates automatically generate manufacturing files:
+
+```python
+# After generate_kicad_project(), templates also generate:
+
+# 1. BOM (Bill of Materials) - CSV format for component ordering
+bom_result = circuit_obj.generate_bom(project_name="my_project")
+
+# 2. PDF Schematic - Documentation and review
+pdf_result = circuit_obj.generate_pdf_schematic(project_name="my_project")
+
+# 3. Gerber Files - PCB manufacturing (JLCPCB, PCBWay, etc.)
+gerber_result = circuit_obj.generate_gerbers(project_name="my_project")
+```
+
+**Generated files:**
+- `my_project/my_project_bom.csv` - Component list with references and values
+- `my_project/my_project_schematic.pdf` - Printable schematic documentation
+- `my_project/gerbers/` - Complete Gerber package for PCB fabrication
+
 """
 
         # Add documentation links
@@ -288,7 +310,8 @@ This project includes the following circuit templates:
 1. **Component Selection**: Use `/find-symbol` and `/find-footprint` to find KiCad components
 2. **Circuit Design**: Write Python code using circuit-synth
 3. **Generate KiCad**: Run the Python file to create KiCad project
-4. **Validate**: Open in KiCad and verify the design
+4. **Manufacturing Files**: Templates automatically generate BOM, PDF, and Gerbers
+5. **Validate**: Open in KiCad and verify the design
 
 ## 📚 Quick Reference
 
@@ -307,6 +330,19 @@ component = Component(
 vcc = Net("VCC_3V3")
 component[1] += vcc
 ```
+
+### Manufacturing Exports
+```python
+# All templates automatically generate manufacturing files:
+circuit_obj.generate_bom(project_name="my_project")          # BOM CSV
+circuit_obj.generate_pdf_schematic(project_name="my_project")  # PDF schematic
+circuit_obj.generate_gerbers(project_name="my_project")      # Gerber files
+```
+
+**Output:**
+- BOM: `my_project/my_project_bom.csv`
+- PDF: `my_project/my_project_schematic.pdf`
+- Gerbers: `my_project/gerbers/` (ready for JLCPCB, PCBWay, etc.)
 
 ---
 


### PR DESCRIPTION
## Summary

Documents that `cs-new-project` templates automatically generate manufacturing files (BOM, PDF schematics, and Gerbers). This is purely a documentation improvement - all templates already had this functionality built in.

## Changes Made

### 1. Updated README Generator (`template_manager.py`)
- ✅ Added new "Manufacturing File Generation" section
- ✅ Code examples showing BOM, PDF, and Gerber generation
- ✅ Lists all generated files with descriptions

### 2. Updated CLAUDE.md Generator (`template_manager.py`)
- ✅ Added manufacturing step to development workflow
- ✅ Added "Manufacturing Exports" quick reference section
- ✅ Shows output file paths

### 3. Updated Success Message (`new_project.py`)
- ✅ Displays "Manufacturing: Templates auto-generate BOM, PDF, and Gerbers"
- ✅ Only shown when circuits are included in project

## Why This Matters

Users were unaware that running a circuit template automatically generates:
- **BOM CSV** - Component list for ordering parts
- **PDF Schematic** - Documentation and review
- **Gerber Files** - Ready for PCB fabrication (JLCPCB, PCBWay, etc.)

All templates already include these calls:
```python
circuit_obj.generate_bom(project_name=...)
circuit_obj.generate_pdf_schematic(project_name=...)
circuit_obj.generate_gerbers(project_name=...)
```

This PR surfaces that existing capability through better documentation.

## Testing

- ✅ Python syntax validation passed
- ✅ `cs-new-project --help` runs successfully
- ✅ No code logic changes - purely documentation

## Impact

- **User-facing**: Users will now know their circuits auto-generate manufacturing files
- **Breaking changes**: None
- **Dependencies**: None

🤖 Generated with [Claude Code](https://claude.com/claude-code)