### PR TITLE
fix: Use project name instead of hardcoded 'main' in JSON generation

### DIFF
--- a/src/circuit_synth/tools/kicad_integration/kicad_to_python_sync.py
+++ b/src/circuit_synth/tools/kicad_integration/kicad_to_python_sync.py
@@ -261,13 +261,13 @@ class KiCadToPythonSyncer:
             if not circuits:
                 raise RuntimeError("Failed to parse KiCad project")
 
-            # Get main circuit
-            main_circuit = circuits.get("main") or list(circuits.values())[0]
+            # Get circuit by project name, fallback to first circuit
+            main_circuit = circuits.get(project_name) or list(circuits.values())[0]
 
             # Convert circuit to JSON format (circuit-synth schema)
             # Transform from models.Circuit format to circuit-synth JSON format
             json_data = {
-                "name": main_circuit.name,
+                "name": project_name,  # Use project name from .kicad_pro, not circuit.name
                 "components": {
                     comp.reference: {
                         "ref": comp.reference,
@@ -289,9 +289,8 @@ class KiCadToPythonSyncer:
                 },
             }
 
-            # Add optional source_file if available
-            if main_circuit.schematic_file:
-                json_data["source_file"] = main_circuit.schematic_file
+            # Add source_file using project name
+            json_data["source_file"] = f"{project_name}.kicad_sch"
 
             # Write JSON file
             with open(json_path, "w", encoding="utf-8") as f:

--- a/src/circuit_synth/tools/utilities/kicad_parser.py
+++ b/src/circuit_synth/tools/utilities/kicad_parser.py
@@ -266,16 +266,16 @@ class KiCadParser:
                     )
             else:
                 logger.info("🔍 HIERARCHICAL DEBUG: Using flat circuit approach")
-                # Single flat circuit
+                # Single flat circuit - use project name instead of hardcoded "main"
                 circuit = Circuit(
-                    name="main",
+                    name=self.kicad_project.stem,
                     components=components,
                     nets=nets,
                     schematic_file=f"{self.kicad_project.stem}.kicad_sch",
                     is_hierarchical_sheet=False,
                     hierarchical_tree=hierarchical_tree,
                 )
-                circuits["main"] = circuit
+                circuits[self.kicad_project.stem] = circuit
                 logger.info(
                     f"🔍 HIERARCHICAL DEBUG: Created flat circuit: {len(components)} components, {len(nets)} nets"
                 )
@@ -335,9 +335,8 @@ class KiCadParser:
             components, net_names = self._parse_schematic_file(sch_file)
 
             # Determine circuit name and type
+            # Use the schematic file stem as the circuit name
             circuit_name = sch_file.stem
-            if circuit_name == self.kicad_project.stem:
-                circuit_name = "main"
 
             logger.info(
                 f"🔍 HIERARCHICAL DEBUG: Circuit '{circuit_name}' from {sch_file.name}:"
@@ -366,9 +365,8 @@ class KiCadParser:
         schematic_files = list(self.project_dir.glob("*.kicad_sch"))
 
         for sch_file in schematic_files:
+            # Use schematic file stem as circuit name
             circuit_name = sch_file.stem
-            if circuit_name == self.kicad_project.stem:
-                circuit_name = "main"
 
             # Parse this schematic file for sheet instances
             logger.info(
@@ -573,9 +571,8 @@ class KiCadParser:
                     not is_main_schematic and sch_file.stem != "root"
                 )
 
+                # Use schematic file stem as circuit name
                 circuit_name = sch_file.stem
-                if is_main_schematic:
-                    circuit_name = "main"
 
                 circuit = Circuit(
                     name=circuit_name,

--- a/src/circuit_synth/tools/utilities/kicad_schematic_parser.py
+++ b/src/circuit_synth/tools/utilities/kicad_schematic_parser.py
@@ -91,8 +91,12 @@ class KiCadSchematicParser:
                     schematic_file=self.schematic_path.name,
                 )
 
-            # Return the main circuit (or first circuit if multiple)
-            if "main" in circuits:
+            # Return the circuit by schematic name, or first circuit if not found
+            circuit_name = self.schematic_path.stem
+            if circuit_name in circuits:
+                circuit = circuits[circuit_name]
+            elif "main" in circuits:
+                # Fallback for old behavior
                 circuit = circuits["main"]
             else:
                 circuit = list(circuits.values())[0]


### PR DESCRIPTION
## Fixes

Closes #321

## Problem

Auto-generated JSON files had hardcoded  instead of using the actual KiCad project name.

**Before:**
```json
{
  "name": "main",
  "source_file": "main.kicad_sch"
}
```

**After:**
```json
{
  "name": "01_kicad_ref",
  "source_file": "01_kicad_ref.kicad_sch"
}
```

## Changes

### kicad_parser.py
- Remove ALL hardcoded 'main' conversions (5 locations)
- Use `self.kicad_project.stem` or `sch_file.stem` for circuit names
- Lines: 271, 278, 340, 370, 576

### kicad_to_python_sync.py  
- Get circuit by `project_name` instead of "main"
- Use `project_name` in JSON data
- Lines: 265, 270, 293

### kicad_schematic_parser.py
- Try schematic name before falling back to "main"
- Lines: 95-102

## Testing

```bash
# Verify JSON has correct name
uv run kicad-to-python tests/bidirectional_new/01_blank_projects/01_kicad_ref/01_kicad_ref.kicad_pro /tmp/test.py
cat tests/bidirectional_new/01_blank_projects/01_kicad_ref/01_kicad_ref.json
# Should show: {"name": "01_kicad_ref", ...}
```

## Known Remaining Issue

Python function name is still `def main():` - this is handled by python_code_generator.py which has 3 hardcoded locations (lines 243, 325, 1186). Will create separate issue for this cosmetic fix.

## Impact

- ✅ JSON files now have correct circuit names
- ✅ Backward compatible (still falls back to "main" if needed)
- ⚠️ Python function names still "main" (separate fix needed)