### PR TITLE
fix: Correct import path for Net class in PCB generator (#360)

### DIFF
--- a/src/circuit_synth/kicad/pcb_gen/pcb_generator.py
+++ b/src/circuit_synth/kicad/pcb_gen/pcb_generator.py
@@ -894,7 +894,7 @@ class PCBGenerator:
                             # Create new net
                             net_num = len(pcb.pcb_data["nets"])
                             # Simplified - create basic net structure
-                            from circuit_synth.pcb.types import Net
+                            # Net is already imported at top of file from kicad_pcb_api.core.types
 
                             new_net = Net(number=net_num, name=unconnected_net_name)
                             pcb.pcb_data["nets"].append(new_net)


### PR DESCRIPTION
## Summary

Fixes #360 - PCB netlist application was failing with `ModuleNotFoundError`.

## Problem

PCB generation was failing silently with:
```
ERROR - Error applying netlist: No module named 'circuit_synth.pcb.types'
```

## Root Cause

Incorrect inline import at `pcb_generator.py:897`:
```python
from circuit_synth.pcb.types import Net  # ❌ This module doesn't exist
```

## Solution

Removed the incorrect import. The correct import already exists at the top of the file (line 19):
```python
from kicad_pcb_api.core.types import Net  # ✅ Already imported
```

## Changes

- **1 line changed** in `src/circuit_synth/kicad/pcb_gen/pcb_generator.py`
- Removed incorrect inline import
- Added comment explaining Net is already imported

## Testing

✅ Ran `tests/bidirectional/03_python_to_kicad/single_resistor.py` - no import error
✅ Full unit test suite: 347 passed, 9 skipped
✅ PCB generation now completes without errors

## Impact

- Low risk: Only removes a broken import that was causing errors
- No functional changes to working code paths
- Enables PCB netlist application to work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)