### PR TITLE
fix: Replace stderr print statements with logger.debug in bbox calculation (#361)

### DIFF
--- a/src/circuit_synth/kicad/sch_gen/symbol_geometry.py
+++ b/src/circuit_synth/kicad/sch_gen/symbol_geometry.py
@@ -318,18 +318,14 @@ class SymbolBoundingBoxCalculator:
         # If no net name match, use minimal fallback to avoid oversized bounding boxes
         if pin_net_map and pin_number in pin_net_map:
             label_text = pin_net_map[pin_number]
-            print(
-                f"  PIN {pin_number}: ✅ USING NET '{label_text}' (len={len(label_text)}), at=({x:.2f}, {y:.2f}), angle={angle}",
-                file=sys.stderr,
-                flush=True,
+            logger.debug(
+                f"PIN {pin_number}: Using net '{label_text}' (len={len(label_text)}), at=({x:.2f}, {y:.2f}), angle={angle}"
             )
         else:
             # No net match - use minimal size (3 chars) instead of potentially long pin name
             label_text = "XXX"  # 3-character placeholder for unmatched pins
-            print(
-                f"  PIN {pin_number}: ⚠️  NO MATCH, using minimal fallback (pin name was '{pin_name}'), at=({x:.2f}, {y:.2f})",
-                file=sys.stderr,
-                flush=True,
+            logger.debug(
+                f"PIN {pin_number}: Using fallback sizing (pin name='{pin_name}'), at=({x:.2f}, {y:.2f})"
             )
 
         if label_text and label_text != "~":  # ~ means no name


### PR DESCRIPTION
## Summary

Fixes #361 - Replaces noisy stderr print statements with proper debug logging.

## Problem

Pin label sizing calculations printed debug messages directly to stderr:
```
PIN 1: ⚠️  NO MATCH, using minimal fallback (pin name was '~')
PIN 2: ⚠️  NO MATCH, using minimal fallback (pin name was '~')
```

This created log noise for all components, even though it's normal behavior for passive components like resistors.

## Solution

Replace `print(file=sys.stderr)` with `logger.debug()` calls. This:
- Keeps output clean during normal operation
- Provides debug info when log level is set to DEBUG
- Works for all pin types without special-casing

## Changes

**One file changed:** `symbol_geometry.py`
- Line 321-323: Replaced print() with logger.debug()
- Line 327-329: Replaced print() with logger.debug()
- Removed warning emoji and alarming language
- **4 insertions, 8 deletions**

## Testing

✅ Ran `single_resistor.py` - clean output, no warnings  
✅ Full unit test suite: 347 passed, 9 skipped  
✅ Debug info still available via `logging.DEBUG` level

## Before/After

### Before (stderr output)
```
PIN 1: ⚠️  NO MATCH, using minimal fallback (pin name was '~')
PIN 2: ⚠️  NO MATCH, using minimal fallback (pin name was '~')
```

### After (normal operation)
```
(clean - no output)
```

### After (with DEBUG logging enabled)
```
DEBUG - PIN 1: Using fallback sizing (pin name='~'), at=(0.00, 3.81)
DEBUG - PIN 2: Using fallback sizing (pin name='~'), at=(0.00, -3.81)
```

## Impact

- **Minimal change:** Only 1 file, 12 lines touched
- **Low risk:** Only changes logging behavior
- **No functional changes** to bbox calculation
- **General solution:** Works for all pin names, no special cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)