### PR TITLE
fix: Fix gerber export tests (Mode 4)

### DIFF
--- a/tests/e2e/test_gerber_export.py
+++ b/tests/e2e/test_gerber_export.py
@@ -20,10 +20,10 @@ class TestCircuitGenerateGerbers:
         """Create a simple test circuit with a few components."""
         @circuit(name="SimpleGerberTest")
         def test_circuit():
-            r1 = Component(symbol="Device:R", value="10k", ref="R1")
-            r2 = Component(symbol="Device:R", value="1k", ref="R2")
-            c1 = Component(symbol="Device:C", value="100nF", ref="C1")
-            d1 = Component(symbol="Device:LED", value="Red", ref="D1")
+            r1 = Component(symbol="Device:R", value="10k", ref="R1", footprint="Resistor_SMD:R_0603_1608Metric")
+            r2 = Component(symbol="Device:R", value="1k", ref="R2", footprint="Resistor_SMD:R_0603_1608Metric")
+            c1 = Component(symbol="Device:C", value="100nF", ref="C1", footprint="Capacitor_SMD:C_0603_1608Metric")
+            d1 = Component(symbol="Device:LED", value="Red", ref="D1", footprint="LED_SMD:LED_0603_1608Metric")
             return locals()
 
         return test_circuit()


### PR DESCRIPTION
## Summary

Fixed 8 failing gerber export tests by addressing three root causes:

1. **Missing footprints in test fixtures**
2. **KiCad CLI argument errors** 
3. **Path resolution issues**

## Changes

### Test Fixtures (`tests/e2e/test_gerber_export.py`)
Added explicit footprint specifications:
```python
r1 = Component(symbol="Device:R", value="10k", ref="R1", footprint="Resistor_SMD:R_0603_1608Metric")
```

### KiCad CLI Wrapper (`src/circuit_synth/pcb/kicad_cli.py`)

**Fixed gerber export arguments**:
- `--layers`: Changed from multiple args to comma-separated list (`F.Cu,B.Cu,...`)
- `--protel-extensions`: Inverted logic (default is enabled, use `--no-protel-ext` to disable)

**Fixed drill export arguments**:
- `--units` → `--excellon-units` for excellon format
- `--mirror-y` → `--excellon-mirror-y` for excellon format  
- `--minimal-header` → `--excellon-min-header` for excellon format

**Fixed path handling**:
- Made output paths absolute with `.resolve()` to prevent files being created relative to command's cwd

## Test Results

Before: 0/8 tests passing  
After: **8/8 tests passing** ✅

## Related Issues

Part of test suite improvement effort. Fixes Mode 4 from test failure analysis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)