### PR TITLE
fix: Change 'connections' to 'nodes' for KiCad netlist compatibility (#373)

### DIFF
--- a/src/circuit_synth/core/netlist_exporter.py
+++ b/src/circuit_synth/core/netlist_exporter.py
@@ -258,14 +258,14 @@ class NetlistExporter:
                 }
                 net_to_pins[net_name].append(pin_connection)
 
-        # Store them in data["nets"] - include both connections and Net properties
+        # Store them in data["nets"] - include both nodes and Net properties
         for net_name, pin_list in net_to_pins.items():
             # Find the Net object to include its metadata
             net_obj = self.circuit._nets.get(net_name)
             if net_obj:
-                # Include Net properties along with connections
+                # Include Net properties along with nodes
                 data["nets"][net_name] = {
-                    "connections": pin_list,
+                    "nodes": pin_list,  # Changed from "connections" to "nodes" for KiCad compatibility
                     "is_power": net_obj.is_power,
                     "power_symbol": net_obj.power_symbol,
                     "trace_current": net_obj.trace_current,
@@ -273,7 +273,7 @@ class NetlistExporter:
                     "properties": net_obj.properties,
                 }
             else:
-                # Fallback: just connections (for backward compatibility)
+                # Fallback: just nodes as direct list (for backward compatibility)
                 data["nets"][net_name] = pin_list
 
         # 3) Recursively gather subcircuits

--- a/src/circuit_synth/kicad/netlist_exporter.py
+++ b/src/circuit_synth/kicad/netlist_exporter.py
@@ -1033,7 +1033,6 @@ def generate_nets_section(circuit_data: Dict[str, Any]) -> List[Any]:
     nets_section = ["nets"]
     net_code = 1
 
-    # Add debug logging
     logger.debug("=== Analyzing net connectivity patterns ===")
 
     # Initialize collections for net analysis

--- a/src/circuit_synth/kicad/netlist_service.py
+++ b/src/circuit_synth/kicad/netlist_service.py
@@ -88,9 +88,10 @@ class CircuitDataLoader:
                 if net_name not in flattened_nets:
                     flattened_nets[net_name] = []
 
-                # Handle both formats: list of connections OR dict with connections key
+                # Handle both formats: list of connections OR dict with nodes key
                 if isinstance(net_data, dict):
-                    net_connections = net_data.get("connections", [])
+                    # Changed from "connections" to "nodes" for KiCad compatibility
+                    net_connections = net_data.get("nodes", net_data.get("connections", []))  # Fall back to "connections" for backward compatibility
                 else:
                     net_connections = net_data  # Old format: just a list
 
@@ -200,11 +201,11 @@ class CircuitReconstructor:
             for net_name, net_info in nets_data.items():
                 # Handle both old format (list) and new format (dict with metadata)
                 if isinstance(net_info, list):
-                    # Old format: just connections
+                    # Old format: just nodes as direct list
                     connections = net_info
                 else:
-                    # New format: dict with connections and metadata
-                    connections = net_info.get("connections", [])
+                    # New format: dict with nodes and metadata (changed from "connections" to "nodes" for KiCad compatibility)
+                    connections = net_info.get("nodes", net_info.get("connections", []))  # Fall back to "connections" for backward compatibility
 
                 # Creating net with connections (verbose logging available if needed)
                 net = Net(net_name)


### PR DESCRIPTION
## Summary

Fixes #373 - Netlist exporter was generating empty `.net` files because of a key mismatch between serialization ("connections") and deserialization ("nodes").

## Root Cause

The `Net` class connection data was serialized with the key `"connections"`, but the KiCad netlist exporter expected `"nodes"`. This caused the validation to fail and skip all nets during export.

## Changes

### 1. `src/circuit_synth/core/netlist_exporter.py` (line 268)
Changed serialization key from `"connections"` to `"nodes"`:
```python
data["nets"][net_name] = {
    "nodes": pin_list,  # Changed from "connections"
    ...
}
```

### 2. `src/circuit_synth/kicad/netlist_service.py` (line 94)
Updated `CircuitDataLoader._flatten_hierarchical_data()` to read `"nodes"`:
```python
net_connections = net_data.get("nodes", net_data.get("connections", []))
```

### 3. `src/circuit_synth/kicad/netlist_service.py` (line 208)
Updated `CircuitReconstructor.reconstruct_circuit()` to read `"nodes"`:
```python
connections = net_info.get("nodes", net_info.get("connections", []))
```

## Test Verification

**Before fix:**
```lisp
(nets))  ← Empty!
```

**After fix:**
```lisp
(nets
  (net (code "1") (name "NET1")
    (node (ref "R1") (pin "1") (pintype "passive"))
    (node (ref "R2") (pin "1") (pintype "passive"))))
```

✅ Test case `tests/bidirectional/10_generate_with_net/two_resistors_connected.py` now correctly generates `.net` files  
✅ No more warning: `Net 'NET1' missing required 'nodes' field`  
✅ Backward compatibility maintained with fallback to `"connections"`

## Checklist

- [x] Code follows CLAUDE.md test-first workflow
- [x] Test case verified (two_resistors_connected.py)
- [x] Backward compatibility maintained
- [x] No breaking changes
- [x] Commit references issue #373

🤖 Generated with [Claude Code](https://claude.com/claude-code)