### PR TITLE
fix: Partial fixes for test failures and kicad-sch-api compatibility

### DIFF
--- a/src/circuit_synth/tools/kicad_integration/kicad_to_python_sync.py
+++ b/src/circuit_synth/tools/kicad_integration/kicad_to_python_sync.py
@@ -168,8 +168,22 @@ class KiCadToPythonSyncer:
 
         # Check for existing JSON
         json_path = project_dir / f"{project_name}.json"
+        kicad_sch = project_dir / f"{project_name}.kicad_sch"
 
+        # Check if JSON exists and is up-to-date
         if json_path.exists():
+            # If .kicad_sch exists, check if it's newer than JSON
+            if kicad_sch.exists():
+                json_mtime = json_path.stat().st_mtime
+                sch_mtime = kicad_sch.stat().st_mtime
+
+                if sch_mtime > json_mtime:
+                    logger.info(
+                        f"JSON is stale (.kicad_sch modified after JSON), "
+                        f"regenerating from schematic..."
+                    )
+                    return self._export_kicad_to_json(kicad_project)
+
             logger.info(f"Found existing JSON: {json_path}")
             return json_path
 

--- a/src/circuit_synth/tools/utilities/kicad_parser.py
+++ b/src/circuit_synth/tools/utilities/kicad_parser.py
@@ -62,7 +62,15 @@ class KiCadParser:
                 if isinstance(sheet_info, list) and len(sheet_info) >= 2:
                     schematic_file, sheet_name = sheet_info[0], sheet_info[1]
                     if sheet_name == "":  # Traditional root sheet has empty name
-                        root_sch_path = self.project_dir / schematic_file
+                        # Check if schematic_file is a UUID (KiCad stores UUIDs, not filenames)
+                        # UUIDs are 36 chars with dashes: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+                        if len(schematic_file) == 36 and schematic_file.count('-') == 4:
+                            # It's a UUID, use project name instead
+                            root_sch_path = self.project_dir / f"{self.kicad_project.stem}.kicad_sch"
+                        else:
+                            # It's a filename
+                            root_sch_path = self.project_dir / schematic_file
+
                         if root_sch_path.exists():
                             logger.info(
                                 f"Found traditional root schematic: {root_sch_path}"

--- a/tests/test_bidirectional_automated/test_component_operations.py
+++ b/tests/test_bidirectional_automated/test_component_operations.py
@@ -48,7 +48,7 @@ class TestComponentOperations:
 
         # Add R2
         sch_path = output_dir / "add_component_test.kicad_sch"
-        sch = ksa.Schematic(str(sch_path))
+        sch = ksa.Schematic.load(str(sch_path))
         sch.components.add(
             lib_id="Device:R",
             reference="R2",
@@ -59,7 +59,7 @@ class TestComponentOperations:
         sch.save()
 
         # Verify
-        sch_verify = ksa.Schematic(str(sch_path))
+        sch_verify = ksa.Schematic.load(str(sch_path))
         assert_schematic_component_count(sch_verify, 2)
         assert_schematic_has_component(sch_verify, "R1", value="10k")
         assert_schematic_has_component(sch_verify, "R2", value="1k")
@@ -97,12 +97,12 @@ class TestComponentOperations:
 
         # Delete R2
         sch_path = output_dir / "delete_component_test.kicad_sch"
-        sch = ksa.Schematic(str(sch_path))
+        sch = ksa.Schematic.load(str(sch_path))
         sch.components.remove("R2")
         sch.save()
 
         # Verify
-        sch_verify = ksa.Schematic(str(sch_path))
+        sch_verify = ksa.Schematic.load(str(sch_path))
         assert_schematic_component_count(sch_verify, 1)
         assert_schematic_has_component(sch_verify, "R1", value="10k")
 
@@ -142,13 +142,13 @@ class TestComponentOperations:
 
         # Change to 22k
         sch_path = output_dir / "modify_value_test.kicad_sch"
-        sch = ksa.Schematic(str(sch_path))
+        sch = ksa.Schematic.load(str(sch_path))
         r1 = sch.components.get("R1")
         r1.value = "22k"
         sch.save()
 
         # Verify
-        sch_verify = ksa.Schematic(str(sch_path))
+        sch_verify = ksa.Schematic.load(str(sch_path))
         assert_schematic_has_component(sch_verify, "R1", value="22k")
 
         # Import and verify
@@ -188,13 +188,13 @@ class TestComponentOperations:
 
         # Rename R1 → R192713402134
         sch_path = output_dir / "rename_component_test.kicad_sch"
-        sch = ksa.Schematic(str(sch_path))
+        sch = ksa.Schematic.load(str(sch_path))
         r1 = sch.components.get("R1")
         r1.reference = "R192713402134"
         sch.save()
 
         # Verify in schematic
-        sch_verify = ksa.Schematic(str(sch_path))
+        sch_verify = ksa.Schematic.load(str(sch_path))
         assert sch_verify.components.get("R1") is None, \
             "Old reference R1 should not exist"
         assert_schematic_has_component(
@@ -233,14 +233,14 @@ class TestComponentOperations:
 
         # Change footprint
         sch_path = output_dir / "modify_footprint_test.kicad_sch"
-        sch = ksa.Schematic(str(sch_path))
+        sch = ksa.Schematic.load(str(sch_path))
         r1 = sch.components.get("R1")
         new_footprint = "Resistor_SMD:R_0805_2012Metric"  # Larger package
         r1.footprint = new_footprint
         sch.save()
 
         # Verify
-        sch_verify = ksa.Schematic(str(sch_path))
+        sch_verify = ksa.Schematic.load(str(sch_path))
         assert_schematic_has_component(
             sch_verify, "R1",
             footprint=new_footprint
@@ -278,7 +278,7 @@ class TestComponentOperations:
         )
 
         sch_path = output_dir / "bulk_operations_test.kicad_sch"
-        sch = ksa.Schematic(str(sch_path))
+        sch = ksa.Schematic.load(str(sch_path))
 
         # Add R3
         sch.components.add(
@@ -298,7 +298,7 @@ class TestComponentOperations:
         sch.save()
 
         # Verify final state
-        sch_verify = ksa.Schematic(str(sch_path))
+        sch_verify = ksa.Schematic.load(str(sch_path))
         assert_schematic_component_count(sch_verify, 2)  # R1, R3 (R2 deleted)
         assert_schematic_has_component(sch_verify, "R1", value="47k")
         assert sch_verify.components.get("R2") is None

--- a/tests/test_bidirectional_automated/test_net_operations.py
+++ b/tests/test_bidirectional_automated/test_net_operations.py
@@ -93,7 +93,7 @@ class TestNetOperations:
 
         # Add net connection using kicad-sch-api
         sch_path = output_dir / "add_net_test.kicad_sch"
-        sch = ksa.Schematic(str(sch_path))
+        sch = ksa.Schematic.load(str(sch_path))
 
         # Get component pin positions
         r1 = sch.components.get("R1")
@@ -110,7 +110,7 @@ class TestNetOperations:
         sch.save()
 
         # Verify
-        sch_verify = ksa.Schematic(str(sch_path))
+        sch_verify = ksa.Schematic.load(str(sch_path))
         assert_net_exists(sch_verify, "NET1")
 
     def test_18_rename_net(self, temp_project_dir, parse_schematic):
@@ -139,7 +139,7 @@ class TestNetOperations:
 
         # Rename NET1 → VCC
         sch_path = output_dir / "rename_net_test.kicad_sch"
-        sch = ksa.Schematic(str(sch_path))
+        sch = ksa.Schematic.load(str(sch_path))
 
         # Find and rename all NET1 labels
         for label in list(sch.labels):
@@ -149,7 +149,7 @@ class TestNetOperations:
         sch.save()
 
         # Verify
-        sch_verify = ksa.Schematic(str(sch_path))
+        sch_verify = ksa.Schematic.load(str(sch_path))
         assert_net_exists(sch_verify, "VCC")
 
         # Verify NET1 gone
@@ -192,7 +192,7 @@ class TestNetOperations:
 
         # Delete NET1 (remove labels and wires)
         sch_path = output_dir / "delete_net_test.kicad_sch"
-        sch = ksa.Schematic(str(sch_path))
+        sch = ksa.Schematic.load(str(sch_path))
 
         # Remove labels
         for label in list(sch.labels):
@@ -206,7 +206,7 @@ class TestNetOperations:
         sch.save()
 
         # Verify net gone
-        sch_verify = ksa.Schematic(str(sch_path))
+        sch_verify = ksa.Schematic.load(str(sch_path))
         net1_labels = [l for l in sch_verify.labels if l.text == "NET1"]
         assert len(net1_labels) == 0, "NET1 labels still exist"
 
@@ -238,7 +238,7 @@ class TestNetOperations:
 
         # Merge NET2 into NET1
         sch_path = output_dir / "merge_nets_test.kicad_sch"
-        sch = ksa.Schematic(str(sch_path))
+        sch = ksa.Schematic.load(str(sch_path))
 
         # Rename all NET2 labels to NET1
         for label in list(sch.labels):
@@ -248,7 +248,7 @@ class TestNetOperations:
         sch.save()
 
         # Verify
-        sch_verify = ksa.Schematic(str(sch_path))
+        sch_verify = ksa.Schematic.load(str(sch_path))
 
         # NET1 exists
         net1_labels = [l for l in sch_verify.labels if l.text == "NET1"]
@@ -287,7 +287,7 @@ class TestNetOperations:
 
         # Split: change one label from NET1 to NET2
         sch_path = output_dir / "split_net_test.kicad_sch"
-        sch = ksa.Schematic(str(sch_path))
+        sch = ksa.Schematic.load(str(sch_path))
 
         # Find first NET1 label and rename to NET2
         net1_labels = [l for l in sch.labels if l.text == "NET1"]
@@ -297,7 +297,7 @@ class TestNetOperations:
         sch.save()
 
         # Verify both nets exist
-        sch_verify = ksa.Schematic(str(sch_path))
+        sch_verify = ksa.Schematic.load(str(sch_path))
         assert_net_exists(sch_verify, "NET1")
         assert_net_exists(sch_verify, "NET2")
 
@@ -386,7 +386,7 @@ class TestNetOperations:
 
         # Add R3 and connect to NET1
         sch_path = output_dir / "add_comp_net_test.kicad_sch"
-        sch = ksa.Schematic(str(sch_path))
+        sch = ksa.Schematic.load(str(sch_path))
 
         # Add R3
         sch.components.add(
@@ -404,7 +404,7 @@ class TestNetOperations:
         sch.save()
 
         # Verify
-        sch_verify = ksa.Schematic(str(sch_path))
+        sch_verify = ksa.Schematic.load(str(sch_path))
         assert_schematic_component_count(sch_verify, 3)
         assert_net_exists(sch_verify, "NET1")
 

--- a/tests/test_bidirectional_automated/test_position_preservation.py
+++ b/tests/test_bidirectional_automated/test_position_preservation.py
@@ -52,7 +52,7 @@ class TestPositionPreservation:
 
         # Get R1's original auto-placed position
         sch_path = output_dir / "position_preservation_test.kicad_sch"
-        sch = ksa.Schematic(str(sch_path))
+        sch = ksa.Schematic.load(str(sch_path))
         r1_original_pos = sch.components.get("R1").position
 
         # Step 2: Manually move R1 to center of page (simulate user action)
@@ -61,7 +61,7 @@ class TestPositionPreservation:
         sch.save()
 
         # Verify move worked
-        sch_moved = ksa.Schematic(str(sch_path))
+        sch_moved = ksa.Schematic.load(str(sch_path))
         r1_moved_pos = sch_moved.components.get("R1").position
         assert_position_near(r1_moved_pos, center_pos, tolerance=0.5)
         assert r1_moved_pos != r1_original_pos, "Position didn't change"
@@ -77,7 +77,7 @@ class TestPositionPreservation:
         sch_moved.save()
 
         # Step 4: Verify R1 STILL at manually-moved position
-        sch_final = ksa.Schematic(str(sch_path))
+        sch_final = ksa.Schematic.load(str(sch_path))
         r1_final_pos = sch_final.components.get("R1").position
 
         # Critical assertion: R1 didn't move back to original position
@@ -125,7 +125,7 @@ class TestPositionPreservation:
 
         # Manually adjust position
         sch_path = output_dir / "regen_position_test.kicad_sch"
-        sch = ksa.Schematic(str(sch_path))
+        sch = ksa.Schematic.load(str(sch_path))
         custom_pos = (100, 150)
         sch.components.get("R1").position = custom_pos
         sch.save()
@@ -137,7 +137,7 @@ class TestPositionPreservation:
         )
 
         # Verify position preserved
-        sch_regen = ksa.Schematic(str(sch_path))
+        sch_regen = ksa.Schematic.load(str(sch_path))
         r1_regen_pos = sch_regen.components.get("R1").position
 
         # Position should be close to custom position
@@ -173,7 +173,7 @@ class TestPositionPreservation:
 
         # Manually position both
         sch_path = output_dir / "delete_position_test.kicad_sch"
-        sch = ksa.Schematic(str(sch_path))
+        sch = ksa.Schematic.load(str(sch_path))
         r1_custom_pos = (100, 100)
         r2_custom_pos = (200, 100)
         sch.components.get("R1").position = r1_custom_pos
@@ -181,12 +181,12 @@ class TestPositionPreservation:
         sch.save()
 
         # Delete R2
-        sch_delete = ksa.Schematic(str(sch_path))
+        sch_delete = ksa.Schematic.load(str(sch_path))
         sch_delete.components.remove("R2")
         sch_delete.save()
 
         # Verify R1 position unchanged
-        sch_final = ksa.Schematic(str(sch_path))
+        sch_final = ksa.Schematic.load(str(sch_path))
         r1_final_pos = sch_final.components.get("R1").position
 
         assert_position_near(r1_final_pos, r1_custom_pos, tolerance=0.5), \
@@ -220,13 +220,13 @@ class TestPositionPreservation:
 
         # Set position to non-grid value
         sch_path = output_dir / "grid_snap_test.kicad_sch"
-        sch = ksa.Schematic(str(sch_path))
+        sch = ksa.Schematic.load(str(sch_path))
         non_grid_pos = (100.123, 100.456)  # Sub-millimeter precision
         sch.components.get("R1").position = non_grid_pos
         sch.save()
 
         # Reload (KiCad may snap to grid)
-        sch_reload = ksa.Schematic(str(sch_path))
+        sch_reload = ksa.Schematic.load(str(sch_path))
         reloaded_pos = sch_reload.components.get("R1").position
 
         # Should be close (within 1mm grid snap tolerance)

--- a/tests/test_bidirectional_automated/test_roundtrip.py
+++ b/tests/test_bidirectional_automated/test_roundtrip.py
@@ -147,7 +147,7 @@ class TestRoundTripConsistency:
 
         # Iteration 2: Add R2 in KiCad
         sch_path = output_dir / "incremental_test.kicad_sch"
-        sch = ksa.Schematic(str(sch_path))
+        sch = ksa.Schematic.load(str(sch_path))
         sch.components.add(
             lib_id="Device:R",
             reference="R2",
@@ -166,7 +166,7 @@ class TestRoundTripConsistency:
         assert "R2" in circuit2.components
 
         # Iteration 3: Add R3 in KiCad
-        sch = ksa.Schematic(str(sch_path))
+        sch = ksa.Schematic.load(str(sch_path))
         sch.components.add(
             lib_id="Device:R",
             reference="R3",


### PR DESCRIPTION
## Summary

This PR provides partial fixes for test failures, addressing kicad-sch-api API compatibility issues and improving JSON regeneration logic.

## Changes Made

### 1. Fixed kicad-sch-api API Compatibility ✅
- Updated all test files to use new API: `Schematic.load(path)` instead of `Schematic(path)`
- **Impact**: Fixes immediate test crashes from API mismatch
- **Files updated**:
  - `tests/test_bidirectional_automated/test_component_operations.py`
  - `tests/test_bidirectional_automated/test_net_operations.py`
  - `tests/test_bidirectional_automated/test_position_preservation.py`
  - `tests/test_bidirectional_automated/test_roundtrip.py`

### 2. Added Stale JSON Detection ✅
- Modified `kicad_to_python_sync.py` to check file modification times
- When `.kicad_sch` is newer than `.json`, JSON is automatically regenerated
- **Impact**: Ensures JSON stays in sync with manual schematic edits
- **File**: `src/circuit_synth/tools/kicad_integration/kicad_to_python_sync.py`

### 3. Fixed KiCadParser UUID Bug ✅
- Fixed `kicad_parser.py` to handle UUID-based sheet references
- KiCad stores UUIDs (not filenames) in `.kicad_pro` sheets array
- Parser now detects UUIDs and uses project name for schematic file
- **Impact**: Eliminates "Root schematic file not found" errors
- **File**: `src/circuit_synth/tools/utilities/kicad_parser.py`

## Test Results

| Metric | Before | After | Change |
|--------|--------|-------|--------|
| Failed | 64 | 62 | ✅ -2 |
| Passed | 669 | 671 | ✅ +2 |

### Remaining Issues ⚠️
- **25 failures** still in `test_bidirectional_automated/`
- **Root cause**: KiCadParser component parsing incomplete
- **Symptom**: Only captures last added component, not all components
- **Needs**: Deeper investigation of `KiCadParser.parse_circuits()` logic

## Technical Details

### UUID Detection Logic
```python
# Check if schematic_file is a UUID (36 chars with 4 dashes)
if len(schematic_file) == 36 and schematic_file.count('-') == 4:
    # It's a UUID, use project name instead
    root_sch_path = self.project_dir / f"{self.kicad_project.stem}.kicad_sch"
```

### Stale Detection Logic
```python
if kicad_sch.exists():
    json_mtime = json_path.stat().st_mtime
    sch_mtime = kicad_sch.stat().st_mtime
    if sch_mtime > json_mtime:
        # Regenerate JSON
```

## Next Steps

To fully fix `test_bidirectional_automated/` tests:
1. Debug `KiCadParser.parse_circuits()` component collection
2. Ensure all components from `.kicad_sch` are captured in JSON
3. Fix hierarchical sheet parsing ("Could not parse sheet block" warnings)

## Related
- Addresses kicad-sch-api v0.4.2 API breaking changes
- Part of ongoing test suite stabilization effort