### PR TITLE
refactor: Remove redundant wire sync workaround

### DIFF
--- a/test_wire_sync.py
+++ b/test_wire_sync.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""
+Test to verify if wire sync issue exists.
+
+This script tests whether wires added via the WireCollection properly
+sync to _data["wire"] without needing manual sync.
+"""
+
+import kicad_sch_api as ksa
+import tempfile
+import os
+
+def test_wire_sync():
+    # Create a blank schematic
+    print("Creating blank schematic...")
+    sch = ksa.create_schematic("test_wire_sync")
+
+    # Add a wire using the public API
+    print("\nAdding wire using schematic.add_wire()...")
+    wire_uuid = sch.add_wire(start=(100, 100), end=(200, 100))
+    print(f"  Wire UUID: {wire_uuid}")
+
+    # Check if wire is in collection
+    wires_in_collection = list(sch.wires)
+    print(f"\n  Wires in collection: {len(wires_in_collection)}")
+    for w in wires_in_collection:
+        print(f"    - {w.uuid}: {w.points}")
+
+    # Check if wire is in _data
+    wires_in_data = sch._data.get("wire", [])
+    print(f"\n  Wires in _data: {len(wires_in_data)}")
+    for w in wires_in_data:
+        print(f"    - {w.get('uuid')}: {w.get('points', [])}")
+
+    # Save and reload
+    with tempfile.TemporaryDirectory() as tmpdir:
+        test_path = os.path.join(tmpdir, "test.kicad_sch")
+        print(f"\nSaving to: {test_path}")
+        sch.save(test_path)
+
+        print("\nReloading schematic...")
+        sch2 = ksa.load_schematic(test_path)
+
+        # Check if wire survived the round-trip
+        wires_after_reload = list(sch2.wires)
+        print(f"\n  Wires after reload: {len(wires_after_reload)}")
+        for w in wires_after_reload:
+            print(f"    - {w.uuid}: {w.points}")
+
+    # Now test removal
+    print("\n\nTesting wire removal...")
+    sch3 = ksa.create_schematic("test_wire_removal")
+
+    # Add two wires
+    wire1_uuid = sch3.add_wire(start=(100, 100), end=(200, 100))
+    wire2_uuid = sch3.add_wire(start=(100, 200), end=(200, 200))
+
+    print(f"  Added wires: {wire1_uuid}, {wire2_uuid}")
+    print(f"  Wires in collection: {len(list(sch3.wires))}")
+    print(f"  Wires in _data: {len(sch3._data.get('wire', []))}")
+
+    # Remove one wire
+    print(f"\nRemoving wire: {wire1_uuid}")
+    removed = sch3.remove_wire(wire1_uuid)
+    print(f"  Removal successful: {removed}")
+
+    print(f"\n  Wires in collection after removal: {len(list(sch3.wires))}")
+    print(f"  Wires in _data after removal: {len(sch3._data.get('wire', []))}")
+
+    # Check UUIDs
+    print("\n  Collection UUIDs:")
+    for w in sch3.wires:
+        print(f"    - {w.uuid}")
+
+    print("\n  _data UUIDs:")
+    for w in sch3._data.get('wire', []):
+        print(f"    - {w.get('uuid')}")
+
+    # Test save/reload after removal
+    with tempfile.TemporaryDirectory() as tmpdir:
+        test_path = os.path.join(tmpdir, "test_removal.kicad_sch")
+        print(f"\nSaving to: {test_path}")
+        sch3.save(test_path)
+
+        print("\nReloading schematic...")
+        sch4 = ksa.load_schematic(test_path)
+
+        print(f"\n  Wires after reload: {len(list(sch4.wires))}")
+        for w in sch4.wires:
+            print(f"    - {w.uuid}")
+
+if __name__ == "__main__":
+    test_wire_sync()


### PR DESCRIPTION
## Summary
Removes 76 lines of redundant wire syncing code that duplicated functionality already provided by kicad-sch-api.

## Problem
The synchronizer contained a manual `_sync_wires_to_data()` workaround that claimed to fix a "kicad-sch-api bug where WireCollection doesn't sync to _data".

**This workaround was completely redundant** - kicad-sch-api's `save()` method already calls `_sync_wires_to_data()` automatically before saving.

## Investigation
Created `test_wire_sync.py` which confirmed:
- ✅ Wires are not synced to _data during add/remove operations (by design)  
- ✅ BUT wires DO save/load correctly because `save()` syncs them automatically
- ❌ The workaround provided zero value and caused duplicate syncing

### Test Evidence
```
Adding wire using schematic.add_wire()...
  Wires in collection: 1
  Wires in _data: 0  ← Not synced yet (by design)

Saving and reloading...
  Wires after reload: 1  ← Wire was saved correctly! ✅

Testing removal...
  Wires in collection after removal: 1
  Wires after reload: 1  ← Removal persisted correctly! ✅
```

## Root Cause
Examination of `kicad-sch-api/core/schematic.py:408-416` shows the `save()` method already calls ALL sync methods:

```python
def save(self, file_path, preserve_format=True):
    # Sync collection state back to data structure (critical for save)
    self._sync_components_to_data()
    self._sync_wires_to_data()           # ← Already synced!
    self._sync_junctions_to_data()
    self._sync_texts_to_data()
    self._sync_labels_to_data()
    self._sync_hierarchical_labels_to_data()
    self._sync_no_connects_to_data()
    self._sync_nets_to_data()
    
    self._file_io_manager.save_schematic(self._data, file_path, preserve_format)
```

**Before**: circuit-synth manually syncs wires, then `save()` syncs them again = duplicate work  
**After**: circuit-synth just calls `save()` which handles syncing = clean and correct

## Changes
- **Deleted** `_sync_wires_to_data()` method (76 lines)
- **Simplified** `_save_schematic()` to just call `schematic.save()`  
- **Added** clarifying comment about kicad-sch-api's automatic syncing

```diff
- # WORKAROUND: kicad-sch-api bug where WireCollection doesn't sync
- self._sync_wires_to_data()
+ # kicad-sch-api's save() automatically syncs all collections
+ # See: kicad_sch_api/core/schematic.py:408-416
```

## Testing
✅ **test_wire_sync.py** - Wires save/load correctly  
✅ **Test 12 (bidirectional sync)** - No regression  
✅ **All existing tests** - Pass

Run tests:
```bash
# Wire sync test
uv run python3 test_wire_sync.py

# Bidirectional test 12
cd tests/bidirectional/12_change_pin_connection
uv run python3 two_resistors_initial.py
```

## Benefits
- ✅ **76 lines removed** - Code cleanup
- ✅ **No duplicate syncing** - Performance improvement
- ✅ **Rely on tested library** - Better maintainability
- ✅ **Remove misleading comment** - Clarity improvement

## Documentation
Created comprehensive PRD: `PRD_Wire_Sync_Workaround.md`
- Full investigation findings
- Test evidence
- Risk assessment

## Related
- Similar workaround was needed for hierarchical labels in #380, but that was a REAL bug
- This investigation proves the wire workaround was overcautious and unnecessary

🤖 Generated with [Claude Code](https://claude.com/claude-code)