### PR TITLE
feat: Update kicad-sch-api to 0.4.5 for hierarchical instance support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     # Cache and performance dependencies
     "cachetools>=5.3.0",
     # KiCad API integration
-    "kicad-sch-api>=0.4.4",  # Requires 0.4.4+ for stable hierarchical label support
+    "kicad-sch-api>=0.4.5",  # Requires 0.4.5+ for hierarchical symbol instance support
     "kicad-pcb-api>=0.1.0",
     "packaging>=21.0",
     # Additional data processing


### PR DESCRIPTION
## Summary

Updates circuit-synth to use kicad-sch-api v0.4.5, which includes proper preservation of hierarchical symbol instances through save/load cycles.

**Fixes**: circuit-synth #406 - Components in hierarchical child sheets now display correct reference designators

## Changes

- Updated `kicad-sch-api>=0.4.4` to `kicad-sch-api>=0.4.5` in pyproject.toml

## Why This Matters

kicad-sch-api v0.4.5 (PR #78) added:
- `instances` field to `SchematicSymbol` dataclass for storing hierarchical paths
- Logic to preserve user-set instances instead of always generating defaults
- Proper round-trip preservation through save/load cycles

This eliminates the need for post-save workarounds in circuit-synth that were previously required to fix hierarchical paths after saving.

## No Breaking Changes

This is a pure dependency update. All existing functionality is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)