### PR TITLE
docs: Document Issue #406 resolution - Hierarchical schematic support complete

### DIFF
--- a/tests/bidirectional/BIDIRECTIONAL_TEST_SUMMARY.md
+++ b/tests/bidirectional/BIDIRECTIONAL_TEST_SUMMARY.md
@@ -1,10 +1,12 @@
 # Bidirectional Test Suite - Comprehensive Summary
 
 **Date:** 2025-10-30
-**Branch:** fix/issue-409-custom-properties
+**Branch:** feat/issue-406-hierarchical-sheets-clean
 **Total Tests:** 65 comprehensive bidirectional tests (01-65)
 **New Tests Added:** 26 tests (39-65)
-**Recently Completed:** Test 29 (Component Custom Properties) - Issue #409 ✅
+**Recently Completed:**
+  - Test 29 (Component Custom Properties) - Issue #409 ✅
+  - Test 22 (Hierarchical Subcircuit Sheets) - Issue #406 ✅ **FIXED & RELEASED**
 
 ## Executive Summary
 
@@ -35,6 +37,29 @@ Execution Time: ~67 seconds for full suite (tests 39-65)
 - ✅ Power distribution through hierarchy (tests 44, 47, 48)
 - ✅ Cross-sheet component operations (tests 41, 42)
 - ✅ Hierarchical pin management (tests 59, 60)
+
+### Issue #406: Hierarchical Sheets - RESOLVED ✅
+
+**Problem:** Components in hierarchical child sheets displayed as "R?" instead of correct reference designators
+
+**Root Cause:** kicad-sch-api was not preserving hierarchical instance paths through save/load cycles
+
+**Solution Implemented:**
+1. **kicad-sch-api v0.4.5** (PR #78 merged, released to PyPI)
+   - Added `instances` field to SchematicSymbol dataclass
+   - Modified save logic to preserve user-set instances instead of generating defaults
+   - Proper round-trip preservation through save/load cycles
+
+2. **circuit-synth PR #417** (merged to main)
+   - Updated dependency: kicad-sch-api >= 0.4.5
+   - No code changes needed - existing instance setting logic now works correctly
+
+3. **Test 22 Validation**
+   - ✅ Generates root sheet with R1 successfully
+   - ✅ Generates child sheet with R2 successfully
+   - ✅ Components appear with correct references in KiCad
+   - ✅ Hierarchical instance paths preserved in .kicad_sch files
+   - ✅ JSON netlist reflects hierarchical structure
 
 ---
 
@@ -158,18 +183,28 @@ Conclusion: ✅ Scales well to realistic circuit sizes
 ### Achievements
 - ✅ 26 new tests created (39-65)
 - ✅ Test 29 completed: Component custom properties (DNP, MPN, Tolerance, complex types) - Issue #409
+- ✅ Test 22 completed: Hierarchical subcircuit sheets - Issue #406 ✅ **FIXED & RELEASED**
 - ✅ Hierarchical operations gap CLOSED
 - ✅ Comprehensive power symbol testing
 - ✅ Real-world workflow integration (DRC, ERC, BOM)
 - ✅ Performance validated (100+ components)
 - ✅ Ultimate integration test (test 64)
 
-### Test Suite Health
-- **Status:** ✅ HEALTHY
-- **Coverage:** Excellent (65 tests)
-- **Documentation:** Comprehensive
-- **CI-Ready:** All tests operational
+### Issue #406 Resolution Summary
 
-**Last Updated:** 2025-10-30 (Test 29 completed - Issue #409)
+**Release Pipeline Completed:**
+1. ✅ kicad-sch-api v0.4.5 released to PyPI
+2. ✅ circuit-synth updated to kicad-sch-api >= 0.4.5
+3. ✅ Test 22 validates end-to-end functionality
+4. ✅ Hierarchical instance paths now preserved correctly
+
+### Test Suite Health
+- **Status:** ✅ HEALTHY + ENHANCED
+- **Coverage:** Excellent (65 tests)
+- **Documentation:** Comprehensive with Issue #406 resolution details
+- **CI-Ready:** All tests operational
+- **Release-Ready:** Issue #406 complete and validated
+
+**Last Updated:** 2025-10-30 (Issue #406 Fixed & Released)
 
 🤖 Generated with [Claude Code](https://claude.com/claude-code)


### PR DESCRIPTION
## Summary

This PR documents the completion of Issue #406 - Hierarchical Schematic Support in circuit-synth.

The underlying fix has been implemented and released via kicad-sch-api v0.4.5 (PR #417 in circuit-synth), but this PR ensures the test documentation is up-to-date.

**Closes**: circuit-synth #406

## What's Documented

✅ **Issue #406: Hierarchical Sheets - RESOLVED**
- Problem: Components in child sheets displayed as "R?" instead of correct reference designators
- Root Cause: kicad-sch-api wasn't preserving hierarchical instance paths through save/load cycles
- Solution: kicad-sch-api v0.4.5 with proper instance preservation
- Validation: Test 22 confirms end-to-end functionality

## Documentation Updates

- Updated BIDIRECTIONAL_TEST_SUMMARY.md with:
  - Issue #406 resolution details
  - kicad-sch-api v0.4.5 release information
  - Test 22 validation status
  - Hierarchical instance path preservation confirmation

## Testing Status

✅ Test 22 (Hierarchical Subcircuit Sheets) validates:
- Root sheet generated with R1
- Child sheet generated with R2
- Components display with correct reference designators
- Hierarchical instance paths preserved in .kicad_sch files
- JSON netlist reflects hierarchical structure

## No Code Changes

This is purely a documentation update. The actual fix was implemented in kicad-sch-api v0.4.5 and integrated via circuit-synth PR #417.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>