### PR TITLE
fix: Enable pytest-asyncio support for async tests (#433)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -223,6 +223,8 @@ markers = [
     "functional: marks tests as functional tests",
     "cache: marks tests as cache-related tests",
 ]
+asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"
 env = [
     "KICAD_SYMBOL_DIR=tests/test_data/kicad_symbols",
 ]


### PR DESCRIPTION
## Summary
- Enable pytest-asyncio configuration to fix 2 async test failures
- Minimal change: only adds 2 configuration lines to pyproject.toml

## Test Results
✅ `test_search_with_cache` - now passing
✅ `test_fallback_search` - now passing

## Changes
- Add `asyncio_mode = "auto"` to pytest config
- Add `asyncio_default_fixture_loop_scope = "function"` to pytest config

Part of #433

🤖 Generated with [Claude Code](https://claude.com/claude-code)