### PR TITLE
fix: Update test_to_dict to use 'nodes' instead of 'connections' (#433)

### DIFF
--- a/tests/unit/test_core_circuit.py
+++ b/tests/unit/test_core_circuit.py
@@ -122,12 +122,12 @@ class TestCircuit:
         # Verify the net has the expected connection (new format: dict with metadata)
         gnd_net = circuit_dict["nets"]["GND"]
         assert isinstance(gnd_net, dict)
-        assert "connections" in gnd_net
+        assert "nodes" in gnd_net
         assert "is_power" in gnd_net
         assert gnd_net["is_power"] is True  # GND is auto-detected as power net
         assert gnd_net["power_symbol"] == "power:GND"
-        assert len(gnd_net["connections"]) == 1
-        assert gnd_net["connections"][0]["component"] == "R1"
+        assert len(gnd_net["nodes"]) == 1
+        assert gnd_net["nodes"][0]["component"] == "R1"
 
 
 class TestComponent:


### PR DESCRIPTION
## Summary
- Fix test expectations to match updated Circuit.to_dict() API
- Minimal change: 3-line test update

## Test Results
✅ `test_to_dict` - now passing

## Root Cause
The Circuit.to_dict() API was updated to use 'nodes' instead of 'connections' 
for net serialization, but the test was not updated to match.

## Changes
- Replace assertion checking for 'connections' key with 'nodes'
- Update all assertions accessing connection data to use 'nodes'

Part of #433

🤖 Generated with [Claude Code](https://claude.com/claude-code)