### PR TITLE
fix: Iterate over component values, not keys, in code generator (#433)

### DIFF
--- a/src/circuit_synth/tools/utilities/python_code_generator.py
+++ b/src/circuit_synth/tools/utilities/python_code_generator.py
@@ -341,7 +341,7 @@ class PythonCodeGenerator:
         # Create components
         if circuit.components:
             code_parts.append("    # Create components")
-            for comp in circuit.components:
+            for comp in circuit.components.values():
                 comp_code = self._generate_component_code(comp, indent="    ")
                 code_parts.extend(comp_code)
 


### PR DESCRIPTION
## Summary
- Fix PythonCodeGenerator component iteration bug
- Minimal change: 1-line fix

## Test Results
✅ `test_circuit_with_no_nets` - now passing
✅ `test_component_reference_sanitization` - now passing

## Root Cause
The bug was caused by iterating over `circuit.components` directly, which 
returns dictionary keys (reference strings) instead of Component objects.

```python
# circuit.components is a dict: {"R1": <Component>, "C1": <Component>}

# Before (incorrect):
for comp in circuit.components:  # comp = "R1" (string)
    comp.value  # AttributeError: 'str' has no attribute 'value'

# After (correct):
for comp in circuit.components.values():  # comp = <Component>
    comp.value  # Works!
```

## Changes
- Change iteration from `circuit.components` to `circuit.components.values()`
- This ensures we iterate over Component objects, not reference strings

Part of #433

🤖 Generated with [Claude Code](https://claude.com/claude-code)