### PR TITLE
fix: Correct schematic filenames in power symbol tests (#433)

### DIFF
--- a/tests/unit/test_power_symbol_generation.py
+++ b/tests/unit/test_power_symbol_generation.py
@@ -134,7 +134,7 @@ class TestPowerSymbolGeneration:
 
             assert result["success"]
 
-            sch_file = Path(tmpdir) / "test_multi" / "test_multi.kicad_sch"
+            sch_file = Path(tmpdir) / "test_multi" / "test_multi_power.kicad_sch"
             content = sch_file.read_text()
 
             # Should have all three power symbols
@@ -231,9 +231,9 @@ class TestNetJSONSerialization:
             assert "GND" in data["nets"]
             gnd_net = data["nets"]["GND"]
 
-            # Should be a dict with connections and metadata
+            # Should be a dict with nodes and metadata
             assert isinstance(gnd_net, dict)
-            assert "connections" in gnd_net
+            assert "nodes" in gnd_net
             assert "is_power" in gnd_net
             assert "power_symbol" in gnd_net
 
@@ -366,7 +366,7 @@ class TestPowerSymbolReferences:
 
             assert result["success"]
 
-            sch_file = Path(tmpdir) / "test_refs" / "test_refs.kicad_sch"
+            sch_file = Path(tmpdir) / "test_refs" / "test_pwr_refs.kicad_sch"
             content = sch_file.read_text()
 
             # Extract all #PWR references


### PR DESCRIPTION
## Summary
- Fix 3 test failures caused by incorrect schematic filename expectations
- Minimal changes: 4 lines updated

## Test Results
✅ `test_multiple_power_nets` - now passing
✅ `test_power_net_serialization` - now passing  
✅ `test_power_symbol_unique_references` - now passing

## Root Cause
Tests were expecting schematic files named after `project_name`, but 
`generate_kicad_project()` creates files named after the `circuit name` 
from the `@circuit` decorator.

**Example:**
```python
@circuit(name="test_multi_power")  # This is the circuit name
def test_multi_power():
    ...

# Called with:
generate_kicad_project(project_name="/tmp/test_multi")  # This is project name

# Creates: /tmp/test_multi/test_multi_power.kicad_sch ✅
# Not:     /tmp/test_multi/test_multi.kicad_sch ❌
```

## Changes
1. `test_multiple_power_nets`: Use `test_multi_power.kicad_sch` instead of `test_multi.kicad_sch`
2. `test_power_net_serialization`: Update `"connections"` → `"nodes"` (API changed)
3. `test_power_symbol_unique_references`: Use `test_pwr_refs.kicad_sch` instead of `test_refs.kicad_sch`

Part of #433

🤖 Generated with [Claude Code](https://claude.com/claude-code)