### PR TITLE
fix: Iterate over circuit.components.values() in phase0 helpers (#433)

### DIFF
--- a/tests/integration/helpers/phase0_helpers.py
+++ b/tests/integration/helpers/phase0_helpers.py
@@ -357,8 +357,8 @@ def compare_circuits_semantic(
     # Compare component properties for matching refs
     common_refs = refs1 & refs2
     for ref in common_refs:
-        comp1 = next(c for c in circuit1.components if c.ref == ref)
-        comp2 = next(c for c in circuit2.components if c.ref == ref)
+        comp1 = next(c for c in circuit1.components.values() if c.ref == ref)
+        comp2 = next(c for c in circuit2.components.values() if c.ref == ref)
 
         if comp1.value != comp2.value:
             differences.append(


### PR DESCRIPTION
Fix dict iteration in phase0_helpers.py helper functions.

circuit.components is a dict, so iterating directly returns keys (strings) not Component objects.

**Changes:**
- Line 360-361: Use .values() when iterating

**Impact:**
Fixes component comparison functions used by phase0 integration tests.

Part of #433

🤖 Generated with [Claude Code](https://claude.com/claude-code)