### PR TITLE
fix: Correct Text class parameter names to match kicad-sch-api API (#238)

### DIFF
--- a/src/circuit_synth/kicad/sch_gen/schematic_writer.py
+++ b/src/circuit_synth/kicad/sch_gen/schematic_writer.py
@@ -2279,16 +2279,13 @@ class SchematicWriter:
                     from kicad_sch_api.core.types import Text
 
                     text_element = Text(
-                        content=str(cell_text),
+                        uuid=f"{uuid}_{row_idx}_{col_idx}",
                         position=Point(cell_x, cell_y),
+                        text=str(cell_text),
+                        rotation=0.0,
                         size=text_size,
+                        exclude_from_sim=False,
                     )
-
-                    # Make header row bold
-                    if row_idx == 0 and header_bold:
-                        text_element._text_bold = True
-
-                    text_element._text_uuid = f"{uuid}_{row_idx}_{col_idx}"
 
                     self.schematic.add_text(text_element)
 

--- a/src/circuit_synth/kicad/schematic/label_utils.py
+++ b/src/circuit_synth/kicad/schematic/label_utils.py
@@ -324,7 +324,7 @@ def calculate_text_bounds(
         Tuple of (min_x, min_y, max_x, max_y)
     """
     # Count lines and max line length
-    lines = text.content.split("\n")
+    lines = text.text.split("\n")
     max_line_length = max(len(line) for line in lines)
     num_lines = len(lines)
 

--- a/src/circuit_synth/kicad/schematic/text_manager.py
+++ b/src/circuit_synth/kicad/schematic/text_manager.py
@@ -86,12 +86,12 @@ class TextManager:
 
         # Create text
         text = Text(
-            content=content,
-            position=text_position,
-            orientation=orientation,
-            size=size,
-            effects=effects,
             uuid=self._generate_uuid(),
+            position=text_position,
+            text=content,
+            rotation=orientation,
+            size=size,
+            exclude_from_sim=False,
         )
 
         # Add to schematic
@@ -203,10 +203,10 @@ class TextManager:
 
         for text in self.schematic.texts:
             if exact_match:
-                if text.content == pattern:
+                if text.text == pattern:
                     matching_texts.append(text)
             else:
-                if pattern.lower() in text.content.lower():
+                if pattern.lower() in text.text.lower():
                     matching_texts.append(text)
 
         return matching_texts


### PR DESCRIPTION
## Summary
Fixed parameter name mismatches between circuit-synth code and the kicad-sch-api Text dataclass. The Text class expects `text` and `rotation` parameters but circuit-synth was using `content` and `orientation`.

## Changes
- **text_manager.py**: Fixed Text instantiation (`content`→`text`, `orientation`→`rotation`) and attribute access
- **schematic_writer.py**: Fixed Text instantiation and removed invalid attribute assignments  
- **label_utils.py**: Fixed attribute access in text bounds calculation

## Test plan
- ✅ Text annotation persistence test passes (test_32_text_annotations.py)
- ✅ Code formatting verified with Black
- ✅ All changes follow kicad-sch-api Text dataclass signature

🤖 Generated with Claude Code