### PR TITLE
fix: Correct power symbol text positioning for all orientations (#458)

### DIFF
--- a/src/circuit_synth/kicad/sch_gen/main_generator.py
+++ b/src/circuit_synth/kicad/sch_gen/main_generator.py
@@ -825,6 +825,9 @@ class SchematicGenerator:
         out_path = self.project_dir / f"{self.project_name}.kicad_sch"
         write_schematic_file(main_sch_expr, str(out_path))
 
+        # Fix power symbol text positions (Issue #458)
+        main_writer._fix_power_symbol_text_positions(str(out_path))
+
         # Now generate other subcircuits recursively
         # Create a mapping to track which circuits have been generated
         generated_circuits = {top_name}
@@ -929,6 +932,9 @@ class SchematicGenerator:
 
                         out_path = self.project_dir / f"{c_name}.kicad_sch"
                         write_schematic_file(sch_expr, str(out_path))
+
+                        # Fix power symbol text positions (Issue #458)
+                        writer._fix_power_symbol_text_positions(str(out_path))
 
                         generated_circuits.add(c_name)
                         made_progress = True


### PR DESCRIPTION
Fixes #458

## Problem
Power symbol text labels (VCC, GND, etc.) were positioned incorrectly relative to the power symbol graphics, causing text to overlap components or be misaligned.

## Root Cause
The `_fix_power_symbol_text_positions` method existed but was never called after writing schematic files. Additionally, the text offset logic didn't account for different symbol types (GND points DOWN, VCC points UP).

## Solution
- Call `_fix_power_symbol_text_positions` after writing both main and subcircuit schematics
- Track power symbol `lib_id` to differentiate GND-type vs VCC-type symbols
- Fix text offset calculations based on symbol type and rotation:
  * **GND-type** (GND, VSS) point DOWN by default → text goes below
  * **VCC-type** (VCC, +3V3, +5V, etc.) point UP by default → text goes above
  * Text is always placed away from the symbol graphic for all rotations (0°, 90°, 180°, 270°)

## Changes
- `main_generator.py`: Call `_fix_power_symbol_text_positions` after writing schematics
- `schematic_writer.py`: 
  - Track `lib_id` in power symbol metadata
  - Implement proper text offset logic for GND vs VCC type symbols
  - Handle all four cardinal rotations correctly

## Testing
✅ **Vertical orientation** (Resistor with VCC/GND):
- VCC pointing UP → text above ✓
- GND pointing DOWN → text below ✓

✅ **All four orientations** (STM32 MCU):
- Left side (rotation 90): VCC text left, GND text right ✓
- Right side (rotation 90): Text positioned correctly ✓  
- Top side (rotation 0/180): Text positioned correctly ✓
- Bottom side (rotation 0/180): Text positioned correctly ✓

## Screenshots
Verified with:
1. Simple resistor circuit with VCC/GND
2. STM32G0 MCU with power symbols on pins 4, 7, 11, 38 (all 4 sides)

All power symbol text labels now appear in the correct position relative to their symbols.