### PR TITLE
test: Add docstring to coordinator.py

### DIFF
--- a/adws/coordinator.py
+++ b/adws/coordinator.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 """
-Circuit-Synth Coordinator - Simple TAC-8 inspired autonomous system
+Circuit-Synth Autonomous Coordinator
 
-Polls GitHub for 'rpi-auto' issues, spawns workers, manages task queue.
+TAC-8 inspired system for autonomous issue resolution.
+See adws/README.md for documentation.
 """
 
 import re

--- a/tests/test_coordinator_docstring.py
+++ b/tests/test_coordinator_docstring.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Test that coordinator.py has the correct docstring"""
+
+import sys
+from pathlib import Path
+
+# Add adws to path
+REPO_ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(REPO_ROOT / "adws"))
+
+import coordinator
+
+
+def test_coordinator_module_docstring():
+    """Test that coordinator.py has the expected module-level docstring"""
+    expected_docstring = """
+Circuit-Synth Autonomous Coordinator
+
+TAC-8 inspired system for autonomous issue resolution.
+See adws/README.md for documentation.
+"""
+
+    actual_docstring = coordinator.__doc__
+
+    # Normalize whitespace for comparison
+    assert actual_docstring is not None, "coordinator.py must have a module docstring"
+
+    # Strip leading/trailing whitespace for comparison
+    expected_clean = expected_docstring.strip()
+    actual_clean = actual_docstring.strip()
+
+    assert actual_clean == expected_clean, (
+        f"Docstring mismatch.\n"
+        f"Expected:\n{expected_clean}\n\n"
+        f"Actual:\n{actual_clean}"
+    )
+
+
+if __name__ == "__main__":
+    test_coordinator_module_docstring()
+    print("✓ Coordinator docstring test passed")


### PR DESCRIPTION
## Summary

Adds the requested module-level docstring to `adws/coordinator.py` as specified in issue #471.

## Changes

- Updated `adws/coordinator.py` module docstring to:
  - Identify the module as "Circuit-Synth Autonomous Coordinator"
  - Reference TAC-8 inspired design
  - Point to documentation in adws/README.md
- Added `tests/test_coordinator_docstring.py` to verify docstring content

## Testing

- ✅ New test passes: `test_coordinator_docstring.py`
- ✅ Docstring matches specification exactly

## Issue

Fixes #471

---

Generated with [Claude Code](https://claude.com/claude-code)