### PR TITLE
fix: Minimal sync fixes - abort on error and rotation bug

### DIFF
--- a/src/circuit_synth/kicad/sch_gen/main_generator.py
+++ b/src/circuit_synth/kicad/sch_gen/main_generator.py
@@ -714,8 +714,10 @@ class SchematicGenerator:
                 traceback.print_exc()
                 print("=" * 80 + "\n")
                 logger.error(f"❌ Update failed: {e}")
-                logger.error("   Falling back to regeneration...")
-                # Fall through to regeneration
+                logger.error("   ABORTING to preserve existing schematic.")
+                logger.error("   Fix the error and try again, or use force_regenerate=True to start fresh.")
+                # Re-raise the exception to abort instead of falling back to regeneration
+                raise
 
         elif project_exists and force_regenerate:
             # User explicitly wants to regenerate

--- a/src/circuit_synth/kicad/schematic/synchronizer.py
+++ b/src/circuit_synth/kicad/schematic/synchronizer.py
@@ -806,7 +806,7 @@ class APISynchronizer:
                         if "effects" not in label_dict:
                             label_dict["effects"] = {}
                         label_dict["effects"]["justify"] = justify
-                        logger.debug(f"Set hierarchical label justify={justify} for rotation={rotation_normalized}°")
+                        logger.debug(f"Set hierarchical label justify={justify} for rotation={label_angle}°")
                         break
 
             logger.debug(f"Label added: '{net_name}' at ({label_pos.x:.2f}, {label_pos.y:.2f}), angle={label_angle:.0f}, justify={justify}, UUID={label_uuid}")


### PR DESCRIPTION
## Summary

This PR contains **only two minimal fixes** for critical sync issues:

1. **Fix undefined variable bug** (synchronizer.py:809)
2. **Abort on error instead of destructive regeneration** (main_generator.py:716-720)

## Changes

### Fix 1: Undefined Variable (synchronizer.py)
**Line 809:** Changed `rotation_normalized` → `label_angle`

This prevents a NameError when creating hierarchical labels during sync operations.

### Fix 2: Abort on Sync Error (main_generator.py)
**Lines 716-720:** Re-raise exception instead of falling back to regeneration

**Before:**
```python
logger.error("❌ Update failed: {e}")
logger.error("   Falling back to regeneration...")
# Fall through to regeneration
```

**After:**
```python
logger.error("❌ Update failed: {e}")
logger.error("   ABORTING to preserve existing schematic.")
logger.error("   Fix the error and try again, or use force_regenerate=True to start fresh.")
raise
```

**Why:** Prevents destructive fallback that would destroy user's manual work (component positions, rotations, wiring) in KiCad.

## Test Results

All tests passing:
```bash
pytest tests/bidirectional/component_crud_root/03_sync_component_root_update_ref/
========================== 3 passed ==========================
✅ test_12_update_component_ref
✅ test_12b_move_rotate_all_components  
✅ test_12c_value_change_preserves_position_rotation
```

## Verified Functionality

- ✅ Component position preservation during sync
- ✅ Component rotation preservation during sync
- ✅ Value updates work correctly (10k → 100k → 220k)
- ✅ Sync aborts gracefully on error instead of destroying work

## Related Issues

The following issues require separate investigation and are **not** addressed by this PR:

- #516 - Power symbol #PWR? validation errors after KiCad edits
- #517 - Label orientation issues on rotated components
- #518 - Component text positioning issues

## Files Changed

- `src/circuit_synth/kicad/schematic/synchronizer.py` (1 line)
- `src/circuit_synth/kicad/sch_gen/main_generator.py` (4 lines)

**Total:** 2 files, 5 insertions(+), 3 deletions(-)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>