### PR TITLE
fix: Add rpi-auto label cleanup to worker template

### DIFF
--- a/worker_template.md
+++ b/worker_template.md
@@ -65,7 +65,12 @@ circuit-synth is a Python library that generates KiCad schematics programmatical
    - Create PR: `gh pr create --fill`
    - Reference the issue: `Fixes #{issue_number}`
 
-7. **Update tasks.md**
+7. **Remove the rpi-auto label**
+   - Run: `gh issue edit {issue_number} --remove-label rpi-auto`
+   - This signals the coordinator that the task is complete
+   - Prevents duplicate workers from being spawned
+
+8. **Update tasks.md**
    - Mark task as complete with commit hash and PR link
 
 ---
@@ -79,6 +84,7 @@ circuit-synth is a Python library that generates KiCad schematics programmatical
 - ✅ Make focused, minimal changes
 - ✅ Commit early and often with clear messages
 - ✅ Create the PR when done
+- ✅ Remove the rpi-auto label after PR creation
 
 **DON'T:**
 - ❌ Make changes without understanding the codebase first
@@ -114,6 +120,7 @@ A human will review and provide guidance.
 You've succeeded when:
 - ✅ Tests pass (including your new test)
 - ✅ PR is created and linked to the issue
+- ✅ rpi-auto label is removed from the issue
 - ✅ tasks.md is updated with completion status
 - ✅ Code follows existing patterns and style
 - ✅ No regressions in existing tests


### PR DESCRIPTION
## Summary

Fixes the autonomous worker duplicate spawning issue by adding explicit label cleanup instructions to the worker template.

## Problem

During autonomous workflow testing (issue #471), we discovered that workers successfully:
- ✅ Created PRs
- ✅ Completed tasks

But did NOT:
- ❌ Remove the `rpi-auto` label from the issue

**Impact:** Coordinator continued to see the label, spawning duplicate workers for the same completed task (resulted in PR #499 and #500 for the same work).

## Solution

Updated `worker_template.md` to add:

### New Step 7: Remove the rpi-auto label
```bash
gh issue edit {issue_number} --remove-label rpi-auto
```

### Updated Guidelines
- Added to success criteria: "rpi-auto label is removed from the issue"
- Added to DO checklist: "Remove the rpi-auto label after PR creation"

## Changes Made

1. **Added Step 7** between PR creation and tasks.md update
2. **Updated Success Criteria** to explicitly check for label removal
3. **Updated DO Guidelines** to remind workers to cleanup labels

## Testing

This fix will prevent the duplicate worker spawning observed in the test run. Future workers will:
1. Create PR (Step 6)
2. Remove `rpi-auto` label (Step 7 - NEW)
3. Update tasks.md (Step 8)

The coordinator's label validation will correctly detect task completion.

## Related Issues

- Observed during #471 autonomous test
- Caused duplicate PRs: #499 and #500
- Related to coordinator task cleanup fix in #498

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>