### PR TITLE
test: Add position preservation test for component deletion

### DIFF
--- a/tests/bidirectional/MANUAL_TEST_CHECKLIST.md
+++ b/tests/bidirectional/MANUAL_TEST_CHECKLIST.md
@@ -23,7 +23,7 @@
 
 - [x] **Test 01**: Create component on root sheet - `component_crud_root/01_sync_component_root_create/` ✅ **Verified 2025-11-02** - R2 added with correct instance data (#479), labels, and power symbols (#489)
 - [ ] **Test 02**: Update component value on root sheet - `component_crud_root/02_sync_component_root_update_value/`
-- [ ] **Test 03**: Update component reference on root sheet - `component_crud_root/03_sync_component_root_update_ref/`
+- [x] **Test 03**: Update component reference on root sheet - `component_crud_root/03_sync_component_root_update_ref/` ✅ **Verified 2025-11-03** - Reference rename (R1→R3), position changes, and value changes all work correctly. Rotation issues tracked in #517, #518
 - [ ] **Test 04**: Delete component from root sheet - `component_crud_root/04_sync_component_root_delete/`
 
 ### Net CRUD - Root Sheet (4 tests)
@@ -152,10 +152,10 @@
 ## 📊 Testing Progress Summary
 
 **Total Tests:** 71
-**Tests Verified:** 1 / 71
+**Tests Verified:** 2 / 71
 
 ### Progress by Category:
-- Component CRUD Root: 1 / 4
+- Component CRUD Root: 2 / 4
 - Net CRUD Root: ___ / 4
 - Component CRUD Hier: ___ / 4
 - Net CRUD Hier: ___ / 4

--- a/tests/bidirectional/component_crud_root/04_sync_component_root_delete/README.md
+++ b/tests/bidirectional/component_crud_root/04_sync_component_root_delete/README.md
@@ -53,17 +53,36 @@ open comprehensive_root/comprehensive_root.kicad_pro
 #   ✅ DATA label present
 ```
 
-## Automated Test
+## Automated Tests
 
 ```bash
+# Test basic deletion
+pytest test_delete_component.py::test_13_delete_component -v
+
+# Test deletion with moved components (position preservation)
+pytest test_delete_component.py::test_13b_delete_with_moved_components -v
+
+# Run all tests
 pytest test_delete_component.py -v
 ```
 
-## Expected Result
+## Expected Results
 
+### Test 13: Basic Deletion
 - ✅ Initial: R1(10k), R2(4.7k), C1(100nF)
 - ✅ After delete: R1(10k), C1(100nF)
 - ✅ R1 position unchanged
 - ✅ C1 position unchanged
 - ✅ Power symbols and labels preserved
 - ✅ Component count: 3 → 2
+
+### Test 13b: Deletion with Moved Components
+- ✅ Initial: R1, R2, C1 at default positions
+- ✅ Move R1 to (50.8, 50.8) and C1 to (100.0, 60.0)
+- ✅ Delete R2 in Python code
+- ✅ Regenerate circuit
+- ✅ **CRITICAL**: R1 and C1 remain at their MOVED positions
+- ✅ Position preservation works correctly!
+
+**Note:** Rotation preservation not tested here due to known issues (#517, #518).
+Only position (X,Y) changes are tested, which work correctly.

--- a/tests/bidirectional/component_crud_root/04_sync_component_root_delete/comprehensive_root.py
+++ b/tests/bidirectional/component_crud_root/04_sync_component_root_delete/comprehensive_root.py
@@ -26,12 +26,12 @@ def comprehensive_root():
         footprint="Resistor_SMD:R_0603_1608Metric"
     )
 
-    r2 = Component(  # Will be deleted in test
-        symbol="Device:R",
-        ref="R2",
-        value="4.7k",
-        footprint="Resistor_SMD:R_0603_1608Metric"
-    )
+    # r2 = Component(  # Will be deleted in test
+    #     symbol="Device:R",
+    #     ref="R2",
+    #     value="4.7k",
+    #     footprint="Resistor_SMD:R_0603_1608Metric"
+    # )
 
     c1 = Component(
         symbol="Device:C",
@@ -51,8 +51,8 @@ def comprehensive_root():
     r1[1] += data
     c1[1] += data
     r1[2] += vcc
-    r2[1] += vcc  # Will be deleted with R2
-    r2[2] += gnd  # Will be deleted with R2
+    # r2[1] += vcc  # Will be deleted with R2
+    # r2[2] += gnd  # Will be deleted with R2
     c1[2] += gnd
 
 

--- a/tests/bidirectional/component_crud_root/04_sync_component_root_delete/test_delete_component.py
+++ b/tests/bidirectional/component_crud_root/04_sync_component_root_delete/test_delete_component.py
@@ -24,6 +24,27 @@ def test_13_delete_component(request):
     cleanup = not request.config.getoption("--keep-output", default=False)
 
     try:
+        # STEP 0: Save original code and uncomment R2 for initial generation
+        original_code = circuit_file.read_text()
+
+        # Uncomment R2 definition and connections
+        code_with_r2 = original_code.replace(
+            '    # r2 = Component(  # Will be deleted in test',
+            '    r2 = Component(  # Will be deleted in test'
+        )
+        code_with_r2 = code_with_r2.replace(
+            '    #     symbol="Device:R",\n    #     ref="R2",',
+            '        symbol="Device:R",\n        ref="R2",'
+        )
+        code_with_r2 = code_with_r2.replace(
+            '    #     value="4.7k",\n    #     footprint="Resistor_SMD:R_0603_1608Metric"\n    # )',
+            '        value="4.7k",\n        footprint="Resistor_SMD:R_0603_1608Metric"\n    )'
+        )
+        code_with_r2 = code_with_r2.replace('    # r2[1] += vcc  # Will be deleted with R2', '    r2[1] += vcc  # Will be deleted with R2')
+        code_with_r2 = code_with_r2.replace('    # r2[2] += gnd  # Will be deleted with R2', '    r2[2] += gnd  # Will be deleted with R2')
+
+        circuit_file.write_text(code_with_r2)
+
         # STEP 1: Generate initial circuit with R1, R2, C1
         result = subprocess.run(
             ["uv", "run", str(circuit_file)],
@@ -50,26 +71,8 @@ def test_13_delete_component(request):
         c1_pos_before = c1_before.position
         c1_value_before = c1_before.value
 
-        # STEP 2: Modify circuit to delete R2
-        original_code = circuit_file.read_text()
-
-        # Comment out R2 definition and connections
-        modified_code = original_code.replace(
-            '    r2 = Component(  # Will be deleted in test',
-            '    # r2 = Component(  # Deleted in test'
-        )
-        modified_code = modified_code.replace(
-            '        symbol="Device:R",\n        ref="R2",',
-            '#        symbol="Device:R",\n#        ref="R2",'
-        )
-        modified_code = modified_code.replace(
-            '        value="4.7k",\n        footprint="Resistor_SMD:R_0603_1608Metric"\n    )',
-            '#        value="4.7k",\n#        footprint="Resistor_SMD:R_0603_1608Metric"\n#    )'
-        )
-        modified_code = modified_code.replace('    r2[1] += vcc  # Will be deleted with R2', '    # r2[1] += vcc  # Deleted with R2')
-        modified_code = modified_code.replace('    r2[2] += gnd  # Will be deleted with R2', '    # r2[2] += gnd  # Deleted with R2')
-
-        circuit_file.write_text(modified_code)
+        # STEP 2: Modify circuit to delete R2 (restore original with R2 commented out)
+        circuit_file.write_text(original_code)
 
         # STEP 3: Regenerate circuit
         result = subprocess.run(
@@ -117,6 +120,144 @@ def test_13_delete_component(request):
         print(f"   - C1: completely unchanged ✓")
         print(f"   - Power symbols: preserved ✓")
         print(f"   - Component count: 3 → 2 ✓")
+
+    finally:
+        if 'original_code' in locals():
+            circuit_file.write_text(original_code)
+
+        if cleanup and output_dir.exists():
+            shutil.rmtree(output_dir)
+
+
+def test_13b_delete_with_moved_components(request):
+    """Test deleting R2 after manually moving components in KiCad.
+
+    This verifies that:
+    1. Moving components in KiCad works
+    2. Deleting a component preserves the moved positions of remaining components
+    """
+
+    test_dir = Path(__file__).parent
+    circuit_file = test_dir / "comprehensive_root.py"
+    output_dir = test_dir / "comprehensive_root"
+    schematic_file = output_dir / "comprehensive_root.kicad_sch"
+
+    cleanup = not request.config.getoption("--keep-output", default=False)
+
+    try:
+        # STEP 0: Save original and uncomment R2
+        original_code = circuit_file.read_text()
+
+        code_with_r2 = original_code.replace(
+            '    # r2 = Component(  # Will be deleted in test',
+            '    r2 = Component(  # Will be deleted in test'
+        )
+        code_with_r2 = code_with_r2.replace(
+            '    #     symbol="Device:R",\n    #     ref="R2",',
+            '        symbol="Device:R",\n        ref="R2",'
+        )
+        code_with_r2 = code_with_r2.replace(
+            '    #     value="4.7k",\n    #     footprint="Resistor_SMD:R_0603_1608Metric"\n    # )',
+            '        value="4.7k",\n        footprint="Resistor_SMD:R_0603_1608Metric"\n    )'
+        )
+        code_with_r2 = code_with_r2.replace('    # r2[1] += vcc  # Will be deleted with R2', '    r2[1] += vcc  # Will be deleted with R2')
+        code_with_r2 = code_with_r2.replace('    # r2[2] += gnd  # Will be deleted with R2', '    r2[2] += gnd  # Will be deleted with R2')
+
+        circuit_file.write_text(code_with_r2)
+
+        # STEP 1: Generate initial circuit
+        result = subprocess.run(
+            ["uv", "run", str(circuit_file)],
+            cwd=test_dir,
+            capture_output=True,
+            text=True,
+            timeout=30
+        )
+        assert result.returncode == 0, f"Initial generation failed: {result.stderr}"
+        assert schematic_file.exists(), "Schematic not generated"
+
+        # STEP 2: Manually move components by modifying schematic file
+        # Simulate user moving components in KiCad GUI
+        sch_content = schematic_file.read_text()
+
+        # Move R1 from default position to (50.8, 50.8)
+        sch_content = sch_content.replace(
+            '(symbol (lib_id "Device:R") (at 30.48',
+            '(symbol (lib_id "Device:R") (at 50.8'
+        )
+        # Move C1 to (100.0, 60.0)
+        sch_content_lines = sch_content.split('\n')
+        in_c1 = False
+        for i, line in enumerate(sch_content_lines):
+            if '(symbol (lib_id "Device:C")' in line and 'C1' in sch_content_lines[i+2]:
+                # Found C1, modify its position line
+                sch_content_lines[i] = line.replace('(at 76.2', '(at 100.0')
+                sch_content_lines[i] = sch_content_lines[i].replace('58.42', '60.0')
+                break
+        sch_content = '\n'.join(sch_content_lines)
+
+        schematic_file.write_text(sch_content)
+
+        # STEP 3: Verify moved positions
+        sch = Schematic.load(str(schematic_file))
+        regular_components = [c for c in sch.components if not c.reference.startswith("#PWR")]
+
+        r1_moved = next(c for c in regular_components if c.reference == "R1")
+        c1_moved = next(c for c in regular_components if c.reference == "C1")
+
+        # Store the NEW moved positions
+        r1_new_x = r1_moved.position.x
+        r1_new_y = r1_moved.position.y
+        c1_new_x = c1_moved.position.x
+        c1_new_y = c1_moved.position.y
+
+        print(f"\n📍 Moved positions:")
+        print(f"   R1: ({r1_new_x:.2f}, {r1_new_y:.2f})")
+        print(f"   C1: ({c1_new_x:.2f}, {c1_new_y:.2f})")
+
+        # STEP 4: Delete R2 in Python code (restore original with R2 commented out)
+        circuit_file.write_text(original_code)
+
+        # STEP 5: Regenerate - should preserve moved positions
+        result = subprocess.run(
+            ["uv", "run", str(circuit_file)],
+            cwd=test_dir,
+            capture_output=True,
+            text=True,
+            timeout=30
+        )
+        assert result.returncode == 0, f"Regeneration failed: {result.stderr}"
+
+        # STEP 6: Verify R2 deleted AND moved positions preserved
+        sch_after = Schematic.load(str(schematic_file))
+        regular_components_after = [c for c in sch_after.components if not c.reference.startswith("#PWR")]
+
+        # Verify R2 deleted
+        assert len(regular_components_after) == 2, f"Expected 2 components, got {len(regular_components_after)}"
+        refs = {c.reference for c in regular_components_after}
+        assert "R2" not in refs, "R2 still exists after delete"
+
+        # Verify moved positions PRESERVED
+        r1_after = next(c for c in regular_components_after if c.reference == "R1")
+        c1_after = next(c for c in regular_components_after if c.reference == "C1")
+
+        # R1 should be at its moved position (50.8, 50.8)
+        assert abs(r1_after.position.x - r1_new_x) < 0.1, \
+            f"R1 X position not preserved: expected {r1_new_x}, got {r1_after.position.x}"
+        assert abs(r1_after.position.y - r1_new_y) < 0.1, \
+            f"R1 Y position not preserved: expected {r1_new_y}, got {r1_after.position.y}"
+
+        # C1 should be at its moved position (100.0, 60.0)
+        assert abs(c1_after.position.x - c1_new_x) < 0.1, \
+            f"C1 X position not preserved: expected {c1_new_x}, got {c1_after.position.x}"
+        assert abs(c1_after.position.y - c1_new_y) < 0.1, \
+            f"C1 Y position not preserved: expected {c1_new_y}, got {c1_after.position.y}"
+
+        print("\n✅ Test 13b PASSED: Deletion preserved moved component positions")
+        print(f"   - R2 deleted ✓")
+        print(f"   - R1 position preserved at ({r1_after.position.x:.2f}, {r1_after.position.y:.2f}) ✓")
+        print(f"   - C1 position preserved at ({c1_after.position.x:.2f}, {c1_after.position.y:.2f}) ✓")
+        print(f"   - Position preservation WORKING! ✓")
 
     finally:
         if 'original_code' in locals():


### PR DESCRIPTION
## Summary

This PR adds comprehensive position preservation testing for component deletion operations, validating one of circuit-synth's killer features based on successful manual testing.

## Changes

### 1. New Test: Position Preservation During Deletion
**test_13b_delete_with_moved_components** - NEW automated test

- Generates circuit with R1, R2, C1
- Moves R1 to (50.8, 50.8) and C1 to (100.0, 60.0) 
- Deletes R2 in Python code
- Regenerates circuit
- **Verifies moved positions are preserved!**
- ✅ PASSING

### 2. Fixed Existing Test
**test_13_delete_component** - Enhanced

- Now properly uncomments R2 before testing
- Tests full deletion workflow correctly
- ✅ PASSING

### 3. Documentation Updates

**MANUAL_TEST_CHECKLIST.md:**
- Marked Test 03 (component reference update) as verified (2025-11-03)
- Noted rotation issues tracked separately (#517, #518)
- Progress: 2/71 tests verified

**README.md:**
- Documents both test scenarios clearly
- Notes rotation not tested due to known issues
- References related GitHub issues

## Test Results

```bash
$ uv run pytest tests/bidirectional/component_crud_root/04_sync_component_root_delete/ -v

tests/.../test_delete_component.py::test_13_delete_component PASSED         [ 50%]
tests/.../test_delete_component.py::test_13b_delete_with_moved_components PASSED [100%]

========================== 2 passed in 6.04s ==========================
```

## Key Finding Validated

Based on extensive manual testing, this PR confirms:

✅ **Position changes work perfectly**
- Moving components in KiCad preserves positions during sync
- Value changes preserve positions
- Reference changes preserve positions

❌ **Rotation changes break** (tracked separately)
- Rotating components causes sync issues
- Tracked in #517 (label orientation)
- Tracked in #518 (component text positioning)

## Impact

This PR:
- ✅ Validates position preservation with automated tests
- ✅ Documents what works vs. what doesn't
- ✅ Prevents regressions in position preservation
- ✅ Provides foundation for future rotation fix testing

## Related Issues

- #516 - Power symbol validation errors
- #517 - Label orientation issues (rotation-specific)
- #518 - Component text positioning (rotation-specific)

## Files Changed

- `tests/bidirectional/MANUAL_TEST_CHECKLIST.md` (+3 lines)
- `tests/bidirectional/component_crud_root/04_sync_component_root_delete/README.md` (+17 lines)
- `tests/bidirectional/component_crud_root/04_sync_component_root_delete/comprehensive_root.py` (R2 commented out)
- `tests/bidirectional/component_crud_root/04_sync_component_root_delete/test_delete_component.py` (+142 lines)

**Total:** 4 files, 193 insertions(+), 33 deletions(-)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>