### PR TITLE
feat: Add validation utilities and KiCAD ERC integration (#570, #571)

### DIFF
--- a/src/circuit_synth/__init__.py
+++ b/src/circuit_synth/__init__.py
@@ -131,6 +131,19 @@ from .core.netlist_exporter import NetlistExporter
 # Reference manager and netlist exporters
 from .core.reference_manager import ReferenceManager
 
+# Quality assurance and validation
+from .quality_assurance import (
+    ERCResults,
+    ERCViolation,
+    KiCADERCError,
+    ValidationIssue,
+    run_erc,
+    validate,
+    validate_manufacturing,
+    validate_naming,
+    validate_properties,
+)
+
 # Removed unused interface abstractions and unified integration
 
 
@@ -192,6 +205,17 @@ __all__ = [
     "require_kicad",
     "get_kicad_paths",
     "KiCadValidationError",
+    # Quality assurance and validation
+    "ValidationIssue",
+    "validate",
+    "validate_properties",
+    "validate_manufacturing",
+    "validate_naming",
+    # ERC
+    "run_erc",
+    "ERCResults",
+    "ERCViolation",
+    "KiCADERCError",
     # Claude Code integration
     "setup_claude_integration",
     # Version utilities

--- a/src/circuit_synth/quality_assurance/__init__.py
+++ b/src/circuit_synth/quality_assurance/__init__.py
@@ -3,6 +3,7 @@ Circuit-Synth Quality Assurance Module
 Provides FMEA, DFM, and other quality analysis tools for circuit designs
 """
 
+from .erc import ERCResults, ERCViolation, KiCADERCError, run_erc
 from .fmea_analyzer import (
     ComponentType,
     FailureMode,
@@ -13,6 +14,13 @@ from .fmea_report_generator import (
     REPORTLAB_AVAILABLE,
     FMEAReportGenerator,
     analyze_circuit_for_fmea,
+)
+from .validation import (
+    ValidationIssue,
+    validate,
+    validate_manufacturing,
+    validate_naming,
+    validate_properties,
 )
 
 # Import enhanced analyzer if available
@@ -32,6 +40,7 @@ except ImportError:
     _has_comprehensive = False
 
 __all__ = [
+    # FMEA
     "FMEAReportGenerator",
     "analyze_circuit_for_fmea",
     "REPORTLAB_AVAILABLE",
@@ -39,6 +48,17 @@ __all__ = [
     "analyze_any_circuit",
     "ComponentType",
     "FailureMode",
+    # Validation
+    "ValidationIssue",
+    "validate",
+    "validate_properties",
+    "validate_manufacturing",
+    "validate_naming",
+    # ERC
+    "run_erc",
+    "ERCResults",
+    "ERCViolation",
+    "KiCADERCError",
 ]
 
 # Add conditional exports

--- a/src/circuit_synth/quality_assurance/erc.py
+++ b/src/circuit_synth/quality_assurance/erc.py
@@ -1,0 +1,239 @@
+"""
+KiCAD Electrical Rules Check (ERC) integration.
+
+Provides Python API to run KiCAD's built-in ERC via kicad-cli command.
+Allows programmatic electrical rule checking without manual KiCAD GUI interaction.
+
+Example:
+    >>> import circuit_synth as cs
+    >>>
+    >>> # Run ERC on a schematic file
+    >>> try:
+    >>>     results = cs.run_erc("design.kicad_sch")
+    >>>     print(f"Errors: {results.error_count}, Warnings: {results.warning_count}")
+    >>>
+    >>>     for violation in results.violations:
+    >>>         print(f"[{violation.severity}] {violation.description}")
+    >>> except cs.KiCADNotFoundError:
+    >>>     print("KiCAD not installed")
+"""
+
+import json
+import subprocess
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+from ..core.kicad_validator import get_kicad_paths, validate_kicad_installation
+from .validation import ValidationIssue
+
+
+@dataclass
+class ERCViolation:
+    """
+    Represents a single ERC violation.
+
+    Attributes:
+        type: Violation type (e.g., 'unconnected_pin', 'pin_conflict')
+        severity: 'error' or 'warning'
+        description: Human-readable violation description
+        location: (x, y) position in schematic (mm)
+        component: Component reference (e.g., 'U1'), if applicable
+        pin: Pin number, if applicable
+        net: Net name, if applicable
+    """
+
+    type: str
+    severity: str
+    description: str
+    location: Optional[Tuple[float, float]] = None
+    component: Optional[str] = None
+    pin: Optional[str] = None
+    net: Optional[str] = None
+
+    def to_validation_issue(self) -> ValidationIssue:
+        """
+        Convert ERC violation to ValidationIssue format.
+
+        Allows integration with other validation utilities.
+
+        Returns:
+            ValidationIssue object
+        """
+        return ValidationIssue(
+            severity=self.severity,
+            message=self.description,
+            check_type="erc",
+            component=self.component,
+            location=self.location,
+        )
+
+
+@dataclass
+class ERCResults:
+    """
+    Results from KiCAD ERC check.
+
+    Attributes:
+        violations: List of ERC violations found
+        error_count: Number of errors
+        warning_count: Number of warnings
+        schematic_path: Path to schematic file checked
+    """
+
+    violations: List[ERCViolation]
+    error_count: int
+    warning_count: int
+    schematic_path: str
+
+    def as_validation_issues(self) -> List[ValidationIssue]:
+        """
+        Convert all ERC violations to ValidationIssue format.
+
+        Allows integration with other validation utilities.
+
+        Returns:
+            List of ValidationIssue objects
+        """
+        return [v.to_validation_issue() for v in self.violations]
+
+    def has_errors(self) -> bool:
+        """Check if any errors were found."""
+        return self.error_count > 0
+
+    def has_warnings(self) -> bool:
+        """Check if any warnings were found."""
+        return self.warning_count > 0
+
+
+class KiCADERCError(Exception):
+    """Raised when KiCAD ERC execution fails."""
+
+    pass
+
+
+def run_erc(
+    schematic_path: str,
+    severity: str = "all",
+    units: str = "mm",
+    kicad_cli_path: Optional[str] = None,
+) -> ERCResults:
+    """
+    Run KiCAD Electrical Rules Check on a schematic.
+
+    Executes kicad-cli sch erc command and parses results.
+    Requires KiCAD 8.0 or later to be installed.
+
+    Args:
+        schematic_path: Path to .kicad_sch file
+        severity: Severity level to report ('all', 'error', 'warning')
+        units: Measurement units for coordinates ('mm', 'in', 'mils')
+        kicad_cli_path: Optional path to kicad-cli executable.
+                       If None, will search standard locations.
+
+    Returns:
+        ERCResults object with violations and counts
+
+    Raises:
+        KiCADNotFoundError: If KiCAD CLI is not found
+        KiCADERCError: If ERC execution fails
+        FileNotFoundError: If schematic file doesn't exist
+
+    Example:
+        >>> results = cs.run_erc("design.kicad_sch")
+        >>> if results.has_errors():
+        ...     print(f"Found {results.error_count} errors!")
+        ...     for v in results.violations:
+        ...         if v.severity == 'error':
+        ...             print(f"  {v.description}")
+    """
+    # Validate schematic file exists
+    sch_path = Path(schematic_path)
+    if not sch_path.exists():
+        raise FileNotFoundError(f"Schematic file not found: {schematic_path}")
+
+    # Find kicad-cli
+    if kicad_cli_path is None:
+        try:
+            kicad_paths = get_kicad_paths()
+            if not validate_kicad_installation():
+                from ..core.kicad_validator import KiCadValidationError
+
+                raise KiCadValidationError("KiCAD CLI not found")
+            kicad_cli_path = kicad_paths.get("kicad-cli")
+        except Exception as e:
+            from ..core.kicad_validator import KiCadValidationError
+
+            raise KiCadValidationError(f"KiCAD CLI not found: {e}")
+
+    # Create temp file for JSON output
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".json", delete=False
+    ) as temp_file:
+        temp_json_path = temp_file.name
+
+    try:
+        # Build kicad-cli command
+        cmd = [
+            str(kicad_cli_path),
+            "sch",
+            "erc",
+            "--format",
+            "json",
+            "--output",
+            temp_json_path,
+            f"--severity-{severity}",
+            "--units",
+            units,
+            str(sch_path),
+        ]
+
+        # Execute kicad-cli
+        result = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=30  # 30 second timeout
+        )
+
+        # kicad-cli returns exit code 5 if violations exist (not an error)
+        if result.returncode not in (0, 5):
+            raise KiCADERCError(
+                f"kicad-cli erc failed with exit code {result.returncode}: {result.stderr}"
+            )
+
+        # Parse JSON output
+        with open(temp_json_path, "r") as f:
+            erc_data = json.load(f)
+
+        # Convert to ERCViolation objects
+        violations = []
+        for v_data in erc_data.get("violations", []):
+            location = None
+            if "location" in v_data:
+                loc = v_data["location"]
+                if "x" in loc and "y" in loc:
+                    location = (loc["x"], loc["y"])
+
+            violation = ERCViolation(
+                type=v_data.get("type", "unknown"),
+                severity=v_data.get("severity", "warning"),
+                description=v_data.get("description", ""),
+                location=location,
+                component=v_data.get("reference"),
+                pin=v_data.get("pin"),
+                net=v_data.get("net"),
+            )
+            violations.append(violation)
+
+        # Create results object
+        results = ERCResults(
+            violations=violations,
+            error_count=erc_data.get("error_count", 0),
+            warning_count=erc_data.get("warning_count", 0),
+            schematic_path=str(schematic_path),
+        )
+
+        return results
+
+    finally:
+        # Clean up temp file
+        Path(temp_json_path).unlink(missing_ok=True)

--- a/src/circuit_synth/quality_assurance/validation.py
+++ b/src/circuit_synth/quality_assurance/validation.py
@@ -1,0 +1,321 @@
+"""
+Schematic validation utilities for design checking.
+
+Provides validation functions to check schematics for:
+- Missing or incomplete component properties
+- Manufacturing readiness
+- Naming convention compliance
+- Design standards
+
+Example:
+    >>> import circuit_synth as cs
+    >>> circuit = cs.Circuit("MyCircuit")
+    >>> r1 = cs.Component("Device:R", ref="R", value="10k")
+    >>> circuit.add_component(r1)
+    >>> circuit.finalize_references()
+    >>>
+    >>> # Validate properties
+    >>> issues = cs.validate_properties(circuit, required=['MPN', 'Package'])
+    >>> for issue in issues:
+    ...     print(f"[{issue.severity}] {issue.component}: {issue.message}")
+    >>>
+    >>> # Validate manufacturing readiness
+    >>> mfg_issues = cs.validate_manufacturing(circuit)
+    >>>
+    >>> # Run all validations
+    >>> all_issues = cs.validate(circuit)
+"""
+
+from dataclasses import dataclass
+from typing import List, Optional
+
+from ..core.circuit import Circuit
+
+
+@dataclass
+class ValidationIssue:
+    """
+    Represents a validation issue found in a schematic.
+
+    Attributes:
+        severity: Issue severity ('error', 'warning', 'info')
+        component: Component reference (if applicable)
+        message: Human-readable issue description
+        location: Position in schematic (if applicable)
+        check_type: Type of check that found this issue
+    """
+
+    severity: str
+    message: str
+    check_type: str
+    component: Optional[str] = None
+    location: Optional[tuple] = None
+
+    def __str__(self) -> str:
+        """Format issue as string."""
+        comp_str = f"{self.component}: " if self.component else ""
+        return f"[{self.severity.upper()}] {comp_str}{self.message}"
+
+
+def validate_properties(
+    circuit: Circuit, required: Optional[List[str]] = None
+) -> List[ValidationIssue]:
+    """
+    Check components have required properties.
+
+    Validates that all components in the circuit have the specified properties.
+    Default required properties are MPN, Package, and Datasheet.
+
+    Args:
+        circuit: Circuit to validate
+        required: List of required property names. If None, uses default list.
+
+    Returns:
+        List of validation issues found
+
+    Example:
+        >>> circuit = cs.Circuit("Test")
+        >>> r1 = cs.Component("Device:R", ref="R", value="10k")
+        >>> circuit.add_component(r1)
+        >>> circuit.finalize_references()
+        >>> issues = cs.validate_properties(circuit, required=['MPN', 'Tolerance'])
+        >>> for issue in issues:
+        ...     print(issue)
+        [WARNING] R1: Missing property: MPN
+        [WARNING] R1: Missing property: Tolerance
+    """
+    issues = []
+    required = required or ["MPN", "Package", "Datasheet"]
+
+    # Iterate over component objects (not keys)
+    for comp in circuit.components.values():
+        for prop in required:
+            # Check if component has this property (stored in _extra_fields)
+            # Properties are accessed as attributes via __getattr__
+            if not hasattr(comp, prop) or getattr(comp, prop, None) is None:
+                issues.append(
+                    ValidationIssue(
+                        severity="warning",
+                        component=comp.ref,
+                        message=f"Missing property: {prop}",
+                        check_type="properties",
+                    )
+                )
+
+    return issues
+
+
+def validate_manufacturing(circuit: Circuit) -> List[ValidationIssue]:
+    """
+    Check manufacturing readiness.
+
+    Validates that the circuit is ready for manufacturing by checking:
+    - All components have footprints (ERROR if missing)
+    - All components have MPN (WARNING if missing)
+    - Resistors have power ratings (WARNING if missing)
+    - Capacitors have voltage ratings (WARNING if missing)
+
+    Args:
+        circuit: Circuit to validate
+
+    Returns:
+        List of validation issues found
+
+    Example:
+        >>> circuit = cs.Circuit("Test")
+        >>> r1 = cs.Component("Device:R", ref="R", value="10k")
+        >>> circuit.add_component(r1)
+        >>> circuit.finalize_references()
+        >>> issues = cs.validate_manufacturing(circuit)
+        >>> errors = [i for i in issues if i.severity == 'error']
+        >>> if errors:
+        ...     print(f"Found {len(errors)} manufacturing errors")
+    """
+    issues = []
+
+    for comp in circuit.components.values():
+        # Missing footprint is an error (blocks manufacturing)
+        if not comp.footprint:
+            issues.append(
+                ValidationIssue(
+                    severity="error",
+                    component=comp.ref,
+                    message="Missing footprint (required for manufacturing)",
+                    check_type="manufacturing",
+                )
+            )
+
+        # Missing MPN is a warning (makes sourcing harder)
+        if not hasattr(comp, "MPN") or not getattr(comp, "MPN", None):
+            issues.append(
+                ValidationIssue(
+                    severity="warning",
+                    component=comp.ref,
+                    message="Missing MPN",
+                    check_type="manufacturing",
+                )
+            )
+
+        # Component-specific checks based on symbol
+        if "Device:R" in comp.symbol or "Resistor" in comp.symbol:
+            # Resistors should have power rating
+            if not hasattr(comp, "Power") or not getattr(comp, "Power", None):
+                issues.append(
+                    ValidationIssue(
+                        severity="warning",
+                        component=comp.ref,
+                        message="Missing power rating",
+                        check_type="manufacturing",
+                    )
+                )
+
+        elif "Device:C" in comp.symbol or "Capacitor" in comp.symbol:
+            # Capacitors should have voltage rating
+            if not hasattr(comp, "Voltage") or not getattr(comp, "Voltage", None):
+                issues.append(
+                    ValidationIssue(
+                        severity="warning",
+                        component=comp.ref,
+                        message="Missing voltage rating",
+                        check_type="manufacturing",
+                    )
+                )
+
+    return issues
+
+
+def validate_naming(circuit: Circuit) -> List[ValidationIssue]:
+    """
+    Validate reference designator naming conventions.
+
+    Checks that components follow standard naming conventions:
+    - Resistors start with 'R'
+    - Capacitors start with 'C'
+    - Inductors start with 'L'
+    - Diodes start with 'D'
+    - ICs start with 'U'
+    - Connectors start with 'J'
+
+    Args:
+        circuit: Circuit to validate
+
+    Returns:
+        List of validation issues found
+
+    Example:
+        >>> circuit = cs.Circuit("Test")
+        >>> r1 = cs.Component("Device:R", ref="R", value="10k")
+        >>> circuit.add_component(r1)
+        >>> circuit.finalize_references()
+        >>> issues = cs.validate_naming(circuit)
+        >>> for issue in issues:
+        ...     print(issue)
+    """
+    issues = []
+
+    # Expected prefix mapping
+    prefix_map = {
+        "Device:R": "R",
+        "Resistor": "R",
+        "Device:C": "C",
+        "Capacitor": "C",
+        "Device:L": "L",
+        "Inductor": "L",
+        "Device:D": "D",
+        "Diode": "D",
+        "Device:LED": "D",  # LEDs typically use D prefix
+        "Connector": "J",
+    }
+
+    for comp in circuit.components.values():
+        # Check if symbol matches any known patterns
+        expected_prefix = None
+        for lib_pattern, prefix in prefix_map.items():
+            if lib_pattern in comp.symbol:
+                expected_prefix = prefix
+                break
+
+        if expected_prefix:
+            if not comp.ref.startswith(expected_prefix):
+                issues.append(
+                    ValidationIssue(
+                        severity="warning",
+                        component=comp.ref,
+                        message=f"Expected prefix '{expected_prefix}' for {comp.symbol}",
+                        check_type="naming",
+                    )
+                )
+
+    # Check for sequential numbering gaps (informational)
+    by_prefix = {}
+    for comp in circuit.components.values():
+        # Extract prefix and number
+        prefix = "".join(c for c in comp.ref if not c.isdigit())
+        number_str = "".join(c for c in comp.ref if c.isdigit())
+        if number_str:
+            by_prefix.setdefault(prefix, []).append(int(number_str))
+
+    for prefix, numbers in by_prefix.items():
+        numbers.sort()
+        expected = list(range(1, len(numbers) + 1))
+        if numbers != expected:
+            issues.append(
+                ValidationIssue(
+                    severity="info",
+                    message=f"Non-sequential numbering for {prefix}: {numbers}",
+                    check_type="naming",
+                )
+            )
+
+    return issues
+
+
+def validate(
+    circuit: Circuit, checks: Optional[List[str]] = None
+) -> List[ValidationIssue]:
+    """
+    Run multiple validation checks on a circuit.
+
+    Convenience function that runs specified validation checks and returns
+    all issues found.
+
+    Args:
+        circuit: Circuit to validate
+        checks: List of check types to run. Available:
+            - 'properties': Check required properties
+            - 'manufacturing': Check manufacturing readiness
+            - 'naming': Check naming conventions
+            - 'all': Run all checks (default)
+
+    Returns:
+        List of all validation issues found
+
+    Example:
+        >>> circuit = cs.Circuit("Test")
+        >>> r1 = cs.Component("Device:R", ref="R", value="10k")
+        >>> circuit.add_component(r1)
+        >>> circuit.finalize_references()
+        >>>
+        >>> # Run all checks
+        >>> all_issues = cs.validate(circuit)
+        >>>
+        >>> # Run specific checks
+        >>> mfg_issues = cs.validate(circuit, checks=['manufacturing'])
+        >>>
+        >>> # Display results
+        >>> for issue in all_issues:
+        ...     print(issue)
+    """
+    checks = checks or ["all"]
+    all_issues = []
+
+    if "all" in checks or "properties" in checks:
+        all_issues.extend(validate_properties(circuit))
+
+    if "all" in checks or "manufacturing" in checks:
+        all_issues.extend(validate_manufacturing(circuit))
+
+    if "all" in checks or "naming" in checks:
+        all_issues.extend(validate_naming(circuit))
+
+    return all_issues

--- a/tests/test_erc.py
+++ b/tests/test_erc.py
@@ -1,0 +1,279 @@
+"""
+Tests for KiCAD ERC integration.
+
+Tests the ERC module that integrates with kicad-cli sch erc command.
+"""
+
+import json
+import subprocess
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+
+import circuit_synth as cs
+
+
+class TestERCViolation:
+    """Test ERCViolation dataclass."""
+
+    def test_erc_violation_creation(self):
+        """Should create ERCViolation with all fields."""
+        violation = cs.ERCViolation(
+            type="unconnected_pin",
+            severity="warning",
+            description="Unconnected Pin 1 on U1",
+            location=(27.94, 17.78),
+            component="U1",
+            pin="1",
+            net="GND",
+        )
+
+        assert violation.type == "unconnected_pin"
+        assert violation.severity == "warning"
+        assert violation.description == "Unconnected Pin 1 on U1"
+        assert violation.location == (27.94, 17.78)
+        assert violation.component == "U1"
+        assert violation.pin == "1"
+        assert violation.net == "GND"
+
+    def test_erc_violation_to_validation_issue(self):
+        """Should convert ERCViolation to ValidationIssue."""
+        violation = cs.ERCViolation(
+            type="unconnected_pin",
+            severity="warning",
+            description="Unconnected Pin 1 on U1",
+            location=(27.94, 17.78),
+            component="U1",
+            pin="1",
+        )
+
+        issue = violation.to_validation_issue()
+
+        assert isinstance(issue, cs.ValidationIssue)
+        assert issue.severity == "warning"
+        assert issue.message == "Unconnected Pin 1 on U1"
+        assert issue.check_type == "erc"
+        assert issue.component == "U1"
+        assert issue.location == (27.94, 17.78)
+
+
+class TestERCResults:
+    """Test ERCResults dataclass."""
+
+    def test_erc_results_creation(self):
+        """Should create ERCResults with violations."""
+        violations = [
+            cs.ERCViolation(
+                type="unconnected_pin",
+                severity="warning",
+                description="Unconnected Pin 1",
+                component="U1",
+            ),
+            cs.ERCViolation(
+                type="pin_conflict",
+                severity="error",
+                description="Output conflict",
+                component="U2",
+            ),
+        ]
+
+        results = cs.ERCResults(
+            violations=violations,
+            error_count=1,
+            warning_count=1,
+            schematic_path="test.kicad_sch",
+        )
+
+        assert len(results.violations) == 2
+        assert results.error_count == 1
+        assert results.warning_count == 1
+        assert results.schematic_path == "test.kicad_sch"
+
+    def test_has_errors(self):
+        """Should detect if errors exist."""
+        results_with_errors = cs.ERCResults(
+            violations=[], error_count=1, warning_count=0, schematic_path="test.sch"
+        )
+        results_without_errors = cs.ERCResults(
+            violations=[], error_count=0, warning_count=1, schematic_path="test.sch"
+        )
+
+        assert results_with_errors.has_errors() is True
+        assert results_without_errors.has_errors() is False
+
+    def test_has_warnings(self):
+        """Should detect if warnings exist."""
+        results_with_warnings = cs.ERCResults(
+            violations=[], error_count=0, warning_count=1, schematic_path="test.sch"
+        )
+        results_without_warnings = cs.ERCResults(
+            violations=[], error_count=0, warning_count=0, schematic_path="test.sch"
+        )
+
+        assert results_with_warnings.has_warnings() is True
+        assert results_without_warnings.has_warnings() is False
+
+    def test_as_validation_issues(self):
+        """Should convert all violations to ValidationIssues."""
+        violations = [
+            cs.ERCViolation(
+                type="unconnected_pin",
+                severity="warning",
+                description="Unconnected Pin 1",
+                component="U1",
+            ),
+            cs.ERCViolation(
+                type="pin_conflict",
+                severity="error",
+                description="Output conflict",
+                component="U2",
+            ),
+        ]
+
+        results = cs.ERCResults(
+            violations=violations,
+            error_count=1,
+            warning_count=1,
+            schematic_path="test.kicad_sch",
+        )
+
+        issues = results.as_validation_issues()
+
+        assert len(issues) == 2
+        assert all(isinstance(i, cs.ValidationIssue) for i in issues)
+        assert issues[0].check_type == "erc"
+        assert issues[1].check_type == "erc"
+
+
+class TestRunERC:
+    """Test run_erc function."""
+
+    @patch("subprocess.run")
+    @patch("circuit_synth.quality_assurance.erc.get_kicad_paths")
+    @patch("circuit_synth.quality_assurance.erc.validate_kicad_installation")
+    def test_run_erc_success(
+        self, mock_validate, mock_get_paths, mock_subprocess, tmp_path
+    ):
+        """Should run ERC successfully and parse results."""
+        # Create temp schematic file
+        sch_file = tmp_path / "test.kicad_sch"
+        sch_file.write_text("(kicad_sch)")
+
+        # Mock KiCAD paths
+        mock_get_paths.return_value = {"kicad-cli": "/usr/bin/kicad-cli"}
+        mock_validate.return_value = True
+
+        # Mock subprocess result
+        mock_result = Mock()
+        mock_result.returncode = 5  # Violations exist
+        mock_result.stderr = ""
+        mock_subprocess.return_value = mock_result
+
+        # Mock JSON output
+        erc_data = {
+            "violations": [
+                {
+                    "type": "unconnected_pin",
+                    "severity": "warning",
+                    "description": "Unconnected Pin 1 on U1",
+                    "location": {"x": 27.94, "y": 17.78},
+                    "reference": "U1",
+                    "pin": "1",
+                }
+            ],
+            "error_count": 0,
+            "warning_count": 1,
+        }
+
+        with patch("builtins.open", create=True) as mock_open:
+            mock_open.return_value.__enter__.return_value.read.return_value = (
+                json.dumps(erc_data)
+            )
+
+            results = cs.run_erc(str(sch_file))
+
+        assert results.error_count == 0
+        assert results.warning_count == 1
+        assert len(results.violations) == 1
+        assert results.violations[0].component == "U1"
+        assert results.violations[0].location == (27.94, 17.78)
+
+    def test_run_erc_file_not_found(self):
+        """Should raise FileNotFoundError for missing schematic."""
+        with pytest.raises(FileNotFoundError):
+            cs.run_erc("nonexistent.kicad_sch")
+
+    @patch("circuit_synth.quality_assurance.erc.get_kicad_paths")
+    @patch("circuit_synth.quality_assurance.erc.validate_kicad_installation")
+    def test_run_erc_kicad_not_found(
+        self, mock_validate, mock_get_paths, tmp_path
+    ):
+        """Should raise error when KiCAD not installed."""
+        # Create temp schematic file
+        sch_file = tmp_path / "test.kicad_sch"
+        sch_file.write_text("(kicad_sch)")
+
+        # Mock KiCAD not found
+        mock_validate.return_value = False
+        mock_get_paths.return_value = {}
+
+        with pytest.raises(Exception):  # Will raise KiCadValidationError
+            cs.run_erc(str(sch_file))
+
+    @patch("subprocess.run")
+    @patch("circuit_synth.quality_assurance.erc.get_kicad_paths")
+    @patch("circuit_synth.quality_assurance.erc.validate_kicad_installation")
+    def test_run_erc_command_failure(
+        self, mock_validate, mock_get_paths, mock_subprocess, tmp_path
+    ):
+        """Should raise error when kicad-cli fails."""
+        # Create temp schematic file
+        sch_file = tmp_path / "test.kicad_sch"
+        sch_file.write_text("(kicad_sch)")
+
+        # Mock KiCAD paths
+        mock_get_paths.return_value = {"kicad-cli": "/usr/bin/kicad-cli"}
+        mock_validate.return_value = True
+
+        # Mock subprocess failure
+        mock_result = Mock()
+        mock_result.returncode = 1  # Error
+        mock_result.stderr = "Command failed"
+        mock_subprocess.return_value = mock_result
+
+        with pytest.raises(cs.KiCADERCError):
+            cs.run_erc(str(sch_file))
+
+
+class TestERCIntegration:
+    """Test ERC integration with validation utilities."""
+
+    def test_erc_integration_with_validation(self):
+        """Should integrate ERC results with other validation checks."""
+        # Create mock ERC results
+        erc_violations = [
+            cs.ERCViolation(
+                type="unconnected_pin",
+                severity="warning",
+                description="Unconnected Pin 1",
+                component="U1",
+            )
+        ]
+
+        erc_results = cs.ERCResults(
+            violations=erc_violations,
+            error_count=0,
+            warning_count=1,
+            schematic_path="test.kicad_sch",
+        )
+
+        # Convert to ValidationIssues
+        all_issues = erc_results.as_validation_issues()
+
+        # Should have ERC issues
+        erc_issues = [i for i in all_issues if i.check_type == "erc"]
+        assert len(erc_issues) == 1
+        assert erc_issues[0].component == "U1"
+        assert erc_issues[0].severity == "warning"

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,464 @@
+"""
+Tests for schematic validation utilities.
+
+Tests the validation functions that check schematics for:
+- Missing or incomplete component properties
+- Manufacturing readiness
+- Naming convention compliance
+"""
+
+import pytest
+
+import circuit_synth as cs
+
+
+class TestValidationIssue:
+    """Test the ValidationIssue dataclass."""
+
+    def test_validation_issue_creation(self):
+        """Should create ValidationIssue with required fields."""
+        issue = cs.ValidationIssue(
+            severity="warning",
+            message="Missing MPN",
+            check_type="properties",
+            component="R1",
+        )
+
+        assert issue.severity == "warning"
+        assert issue.message == "Missing MPN"
+        assert issue.check_type == "properties"
+        assert issue.component == "R1"
+        assert issue.location is None
+
+    def test_validation_issue_str(self):
+        """Should format issue as string."""
+        issue = cs.ValidationIssue(
+            severity="warning",
+            message="Missing MPN",
+            check_type="properties",
+            component="R1",
+        )
+
+        result = str(issue)
+
+        assert "[WARNING]" in result
+        assert "R1:" in result
+        assert "Missing MPN" in result
+
+    def test_validation_issue_without_component(self):
+        """Should format issue without component reference."""
+        issue = cs.ValidationIssue(
+            severity="info", message="Non-sequential numbering", check_type="naming"
+        )
+
+        result = str(issue)
+
+        assert "[INFO]" in result
+        assert "Non-sequential numbering" in result
+
+
+class TestValidateProperties:
+    """Test validate_properties function."""
+
+    def test_validate_properties_missing_mpn(self):
+        """Should detect missing MPN property."""
+        circuit = cs.Circuit("Test")
+        r1 = cs.Component("Device:R", ref="R", value="10k")
+        circuit.add_component(r1)
+        circuit.finalize_references()
+
+        issues = cs.validate_properties(circuit)
+
+        # Should have warning for missing MPN
+        mpn_issues = [i for i in issues if "MPN" in i.message and i.component == "R1"]
+        assert len(mpn_issues) > 0
+        assert all(i.severity == "warning" for i in mpn_issues)
+
+    def test_validate_properties_missing_package(self):
+        """Should detect missing Package property."""
+        circuit = cs.Circuit("Test")
+        r1 = cs.Component("Device:R", ref="R", value="10k")
+        circuit.add_component(r1)
+        circuit.finalize_references()
+
+        issues = cs.validate_properties(circuit)
+
+        # Should have warning for missing Package
+        package_issues = [
+            i for i in issues if "Package" in i.message and i.component == "R1"
+        ]
+        assert len(package_issues) > 0
+
+    def test_validate_properties_missing_datasheet(self):
+        """Should detect missing Datasheet property."""
+        circuit = cs.Circuit("Test")
+        r1 = cs.Component("Device:R", ref="R", value="10k")
+        circuit.add_component(r1)
+        circuit.finalize_references()
+
+        issues = cs.validate_properties(circuit)
+
+        # Should have warning for missing Datasheet
+        datasheet_issues = [
+            i for i in issues if "Datasheet" in i.message and i.component == "R1"
+        ]
+        assert len(datasheet_issues) > 0
+
+    def test_validate_properties_custom_required(self):
+        """Should check custom required properties."""
+        circuit = cs.Circuit("Test")
+        r1 = cs.Component("Device:R", ref="R", value="10k")
+        circuit.add_component(r1)
+        circuit.finalize_references()
+
+        issues = cs.validate_properties(circuit, required=["Tolerance"])
+
+        # Should have warning for missing Tolerance
+        tolerance_issues = [
+            i for i in issues if "Tolerance" in i.message and i.component == "R1"
+        ]
+        assert len(tolerance_issues) > 0
+
+    def test_validate_properties_all_present(self):
+        """Should pass when all properties present."""
+        circuit = cs.Circuit("Test")
+        r1 = cs.Component("Device:R", ref="R", value="10k")
+        circuit.add_component(r1)
+        circuit.finalize_references()
+        r1.MPN = "RC0603FR-0710KL"
+        r1.Package = "0603"
+        r1.Datasheet = "https://example.com/datasheet.pdf"
+
+        issues = cs.validate_properties(circuit)
+
+        # Should have no issues for R1
+        r1_issues = [i for i in issues if i.component == "R1"]
+        assert len(r1_issues) == 0
+
+
+class TestValidateManufacturing:
+    """Test validate_manufacturing function."""
+
+    def test_validate_manufacturing_missing_footprint_error(self):
+        """Should error on missing footprint."""
+        circuit = cs.Circuit("Test")
+        r1 = cs.Component("Device:R", ref="R", value="10k")
+        circuit.add_component(r1)
+        circuit.finalize_references()
+        # Clear footprint
+        r1.footprint = ""
+
+        issues = cs.validate_manufacturing(circuit)
+
+        # Should have ERROR for missing footprint
+        footprint_issues = [
+            i
+            for i in issues
+            if i.component == "R1" and "footprint" in i.message.lower()
+        ]
+        assert len(footprint_issues) > 0
+        assert any(i.severity == "error" for i in footprint_issues)
+
+    def test_validate_manufacturing_missing_mpn_warning(self):
+        """Should warn on missing MPN."""
+        circuit = cs.Circuit("Test")
+        r1 = cs.Component("Device:R", ref="R", value="10k")
+        circuit.add_component(r1)
+        circuit.finalize_references()
+
+        issues = cs.validate_manufacturing(circuit)
+
+        # Should have WARNING for missing MPN
+        mpn_issues = [
+            i for i in issues if i.component == "R1" and "MPN" in i.message
+        ]
+        assert len(mpn_issues) > 0
+        assert all(i.severity == "warning" for i in mpn_issues)
+
+    def test_validate_manufacturing_resistor_missing_power(self):
+        """Should warn on resistor missing power rating."""
+        circuit = cs.Circuit("Test")
+        r1 = cs.Component("Device:R", ref="R", value="10k")
+        circuit.add_component(r1)
+        circuit.finalize_references()
+
+        issues = cs.validate_manufacturing(circuit)
+
+        # Should have WARNING for missing power rating
+        power_issues = [
+            i for i in issues if i.component == "R1" and "power" in i.message.lower()
+        ]
+        assert len(power_issues) > 0
+        assert all(i.severity == "warning" for i in power_issues)
+
+    def test_validate_manufacturing_capacitor_missing_voltage(self):
+        """Should warn on capacitor missing voltage rating."""
+        circuit = cs.Circuit("Test")
+        c1 = cs.Component("Device:C", ref="C", value="10uF")
+        circuit.add_component(c1)
+        circuit.finalize_references()
+
+        issues = cs.validate_manufacturing(circuit)
+
+        # Should have WARNING for missing voltage rating
+        voltage_issues = [
+            i for i in issues if i.component == "C1" and "voltage" in i.message.lower()
+        ]
+        assert len(voltage_issues) > 0
+        assert all(i.severity == "warning" for i in voltage_issues)
+
+    def test_validate_manufacturing_all_checks_pass(self):
+        """Should pass when all manufacturing checks satisfied."""
+        circuit = cs.Circuit("Test")
+        r1 = cs.Component("Device:R", ref="R", value="10k", footprint="Resistor_SMD:R_0603_1608Metric")
+        circuit.add_component(r1)
+        circuit.finalize_references()
+        r1.MPN = "RC0603FR-0710KL"
+        r1.Power = "0.1W"
+
+        issues = cs.validate_manufacturing(circuit)
+
+        # Should have no manufacturing errors
+        r1_errors = [i for i in issues if i.component == "R1" and i.severity == "error"]
+        assert len(r1_errors) == 0
+
+
+class TestValidateNaming:
+    """Test validate_naming function."""
+
+    def test_validate_naming_resistor_correct_prefix(self):
+        """Should accept correct R prefix for resistor."""
+        circuit = cs.Circuit("Test")
+        r1 = cs.Component("Device:R", ref="R", value="10k")
+        circuit.add_component(r1)
+        circuit.finalize_references()
+
+        issues = cs.validate_naming(circuit)
+
+        # Should have no prefix issues for R1
+        r1_prefix_issues = [
+            i for i in issues if i.component == "R1" and "prefix" in i.message.lower()
+        ]
+        assert len(r1_prefix_issues) == 0
+
+    def test_validate_naming_resistor_wrong_prefix(self):
+        """Should detect wrong prefix for resistor."""
+        circuit = cs.Circuit("Test")
+        # Manually create component with wrong reference
+        r1 = cs.Component("Device:R", ref="X1", value="10k")
+        circuit.add_component(r1)
+
+        issues = cs.validate_naming(circuit)
+
+        # Should have warning for wrong prefix
+        prefix_issues = [
+            i
+            for i in issues
+            if i.component == "X1" and "Expected prefix 'R'" in i.message
+        ]
+        assert len(prefix_issues) > 0
+        assert all(i.severity == "warning" for i in prefix_issues)
+
+    def test_validate_naming_capacitor_correct_prefix(self):
+        """Should accept correct C prefix for capacitor."""
+        circuit = cs.Circuit("Test")
+        c1 = cs.Component("Device:C", ref="C", value="10uF")
+        circuit.add_component(c1)
+        circuit.finalize_references()
+
+        issues = cs.validate_naming(circuit)
+
+        # Should have no prefix issues for C1
+        c1_prefix_issues = [
+            i for i in issues if i.component == "C1" and "prefix" in i.message.lower()
+        ]
+        assert len(c1_prefix_issues) == 0
+
+    def test_validate_naming_sequential_numbering(self):
+        """Should detect non-sequential numbering."""
+        circuit = cs.Circuit("Test")
+        r1 = cs.Component("Device:R", ref="R1", value="10k")
+        r5 = cs.Component("Device:R", ref="R5", value="20k")  # Gap in numbering
+        circuit.add_component(r1)
+        circuit.add_component(r5)
+
+        issues = cs.validate_naming(circuit)
+
+        # Should have info about non-sequential numbering
+        sequential_issues = [
+            i for i in issues if "Non-sequential" in i.message and i.severity == "info"
+        ]
+        assert len(sequential_issues) > 0
+
+    def test_validate_naming_sequential_numbering_ok(self):
+        """Should accept sequential numbering."""
+        circuit = cs.Circuit("Test")
+        r1 = cs.Component("Device:R", ref="R", value="10k")
+        r2 = cs.Component("Device:R", ref="R", value="20k")
+        r3 = cs.Component("Device:R", ref="R", value="30k")
+        circuit.add_component(r1)
+        circuit.add_component(r2)
+        circuit.add_component(r3)
+        circuit.finalize_references()
+
+        issues = cs.validate_naming(circuit)
+
+        # Should have no sequential numbering issues for R
+        sequential_issues = [
+            i for i in issues if "Non-sequential" in i.message and "R" in i.message
+        ]
+        assert len(sequential_issues) == 0
+
+
+class TestValidate:
+    """Test the main validate function."""
+
+    def test_validate_runs_all_checks(self):
+        """Should run all checks by default."""
+        circuit = cs.Circuit("Test")
+        r1 = cs.Component("Device:R", ref="R", value="10k")
+        # Add a component with wrong prefix to ensure naming check finds an issue
+        x1 = cs.Component("Device:R", ref="X1", value="20k")
+        circuit.add_component(r1)
+        circuit.add_component(x1)
+        circuit.finalize_references()
+
+        issues = cs.validate(circuit)
+
+        # Should have issues from multiple check types
+        check_types = {i.check_type for i in issues}
+        assert "properties" in check_types
+        assert "manufacturing" in check_types
+        assert "naming" in check_types
+
+    def test_validate_runs_specific_checks(self):
+        """Should run only specified checks."""
+        circuit = cs.Circuit("Test")
+        r1 = cs.Component("Device:R", ref="R", value="10k")
+        circuit.add_component(r1)
+        circuit.finalize_references()
+
+        issues = cs.validate(circuit, checks=["properties"])
+
+        # Should only have properties checks
+        check_types = {i.check_type for i in issues}
+        assert "properties" in check_types
+        assert "manufacturing" not in check_types
+        assert "naming" not in check_types
+
+    def test_validate_multiple_specific_checks(self):
+        """Should run multiple specified checks."""
+        circuit = cs.Circuit("Test")
+        r1 = cs.Component("Device:R", ref="R", value="10k")
+        circuit.add_component(r1)
+        circuit.finalize_references()
+
+        issues = cs.validate(circuit, checks=["properties", "manufacturing"])
+
+        # Should have properties and manufacturing checks
+        check_types = {i.check_type for i in issues}
+        assert "properties" in check_types
+        assert "manufacturing" in check_types
+        assert "naming" not in check_types
+
+    def test_validate_returns_list(self):
+        """Should return list of ValidationIssue objects."""
+        circuit = cs.Circuit("Test")
+        r1 = cs.Component("Device:R", ref="R", value="10k")
+        circuit.add_component(r1)
+        circuit.finalize_references()
+
+        issues = cs.validate(circuit)
+
+        assert isinstance(issues, list)
+        assert all(isinstance(i, cs.ValidationIssue) for i in issues)
+
+    def test_validate_empty_circuit(self):
+        """Should handle empty circuit."""
+        circuit = cs.Circuit("Test")
+
+        issues = cs.validate(circuit)
+
+        # Empty circuit should have no issues
+        assert isinstance(issues, list)
+        assert len(issues) == 0
+
+
+class TestValidationWorkflow:
+    """Test real-world validation workflows."""
+
+    def test_workflow_find_all_errors(self):
+        """User can find all errors in circuit."""
+        circuit = cs.Circuit("Test")
+        r1 = cs.Component("Device:R", ref="R", value="10k")
+        circuit.add_component(r1)
+        circuit.finalize_references()
+        r1.footprint = ""  # Remove footprint
+
+        issues = cs.validate(circuit)
+        errors = [i for i in issues if i.severity == "error"]
+
+        assert len(errors) > 0
+        assert all(isinstance(e, cs.ValidationIssue) for e in errors)
+
+    def test_workflow_filter_by_severity(self):
+        """User can filter issues by severity."""
+        circuit = cs.Circuit("Test")
+        r1 = cs.Component("Device:R", ref="R", value="10k")
+        circuit.add_component(r1)
+        circuit.finalize_references()
+
+        issues = cs.validate(circuit)
+
+        # Filter warnings
+        warnings = [i for i in issues if i.severity == "warning"]
+        assert len(warnings) > 0
+
+    def test_workflow_filter_by_component(self):
+        """User can filter issues by component."""
+        circuit = cs.Circuit("Test")
+        r1 = cs.Component("Device:R", ref="R", value="10k")
+        r2 = cs.Component("Device:R", ref="R", value="20k")
+        circuit.add_component(r1)
+        circuit.add_component(r2)
+        circuit.finalize_references()
+
+        issues = cs.validate(circuit)
+
+        # Filter by component
+        r1_issues = [i for i in issues if i.component == "R1"]
+        r2_issues = [i for i in issues if i.component == "R2"]
+
+        assert len(r1_issues) > 0
+        assert len(r2_issues) > 0
+
+    def test_workflow_print_formatted_report(self):
+        """User can print formatted validation report."""
+        circuit = cs.Circuit("Test")
+        r1 = cs.Component("Device:R", ref="R", value="10k")
+        circuit.add_component(r1)
+        circuit.finalize_references()
+
+        issues = cs.validate(circuit)
+
+        # Print formatted report
+        report = "\n".join(str(issue) for issue in issues)
+
+        assert len(report) > 0
+        assert "[" in report  # Has severity markers
+        assert "R1" in report  # Has component references
+
+    def test_workflow_manufacturing_readiness(self):
+        """User can check manufacturing readiness."""
+        circuit = cs.Circuit("Test")
+        r1 = cs.Component("Device:R", ref="R", value="10k", footprint="Resistor_SMD:R_0603_1608Metric")
+        circuit.add_component(r1)
+        circuit.finalize_references()
+        r1.MPN = "RC0603FR-0710KL"
+        r1.Power = "0.1W"
+
+        issues = cs.validate_manufacturing(circuit)
+        errors = [i for i in issues if i.severity == "error"]
+
+        # Should have no manufacturing errors
+        assert len(errors) == 0


### PR DESCRIPTION
## Summary
Implements comprehensive design checking capabilities combining custom validation utilities with KiCAD's built-in Electrical Rules Check (ERC).

## Changes

### Validation Utilities (#570)
- Added `ValidationIssue` dataclass for representing validation issues with severity levels
- Added `validate_properties()` - Check for missing component properties (MPN, Package, Datasheet)
- Added `validate_manufacturing()` - Check manufacturing readiness (footprints, power/voltage ratings)
- Added `validate_naming()` - Validate reference designator naming conventions  
- Added `validate()` - Convenience function to run all checks

### KiCAD ERC Integration (#571)
- Added `run_erc()` - Run KiCAD's ERC via kicad-cli command
- Added `ERCResults` and `ERCViolation` classes for parsed results
- Added `KiCADERCError` exception for error handling
- Seamless conversion to `ValidationIssue` format
- Graceful degradation when KiCAD not installed

## Usage Example

```python
import circuit_synth as cs

# Run custom validation checks
circuit = cs.Circuit("MyDesign")
# ... add components ...

issues = cs.validate(circuit)

# Run KiCAD ERC (if available)
try:
    erc_results = cs.run_erc("design.kicad_sch")
    issues.extend(erc_results.as_validation_issues())
except cs.KiCADERCError:
    print("KiCAD not available, skipping ERC")

# Display all issues
for issue in issues:
    print(f"[{issue.severity}] {issue.component}: {issue.message}")
```

## Test Plan
- ✅ 28 validation tests passing
- ✅ 11 ERC integration tests passing
- ✅ Total: 39 tests passing
- ✅ Tests cover all validation functions
- ✅ Tests cover ERC execution, parsing, and error handling
- ✅ Tests cover integration between validation and ERC

## Related Issues
Closes #570
Closes #571

## Notes
- KiCAD ERC requires KiCAD 8.0+ to be installed
- ERC gracefully degrades if KiCAD not available
- Both features integrate seamlessly via `ValidationIssue` format

🤖 Generated with [Claude Code](https://claude.com/claude-code)