### PR TITLE
feat: Add BOM property management wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -567,6 +567,7 @@ Automatically exports all standard PCB layers:
 
 - **Automatic Source Reference Rewriting**: Keep Python and KiCad refs synchronized (see above)
 - **Bill of Materials Export**: Generate manufacturing-ready BOMs in CSV format (see above)
+- **BOM Property Management**: Audit, update, and transform component properties for manufacturing compliance
 - **PDF Schematic Export**: Generate professional PDF schematics with formatting options (see above)
 - **Gerber Manufacturing Files**: Generate complete PCB manufacturing files (Gerbers + drill) (see above)
 - **Professional KiCad Output**: Generate .kicad_pro, .kicad_sch, .kicad_pcb files with modern kicad-sch-api integration

--- a/src/circuit_synth/kicad/__init__.py
+++ b/src/circuit_synth/kicad/__init__.py
@@ -1,5 +1,7 @@
 """KiCad integration package."""
 
+from .bom_exporter import BOMExporter
+from .bom_manager import BOMPropertyManager
 from .kicad_symbol_cache import SymbolLibCache
 
-__all__ = ["SymbolLibCache"]
+__all__ = ["BOMExporter", "BOMPropertyManager", "SymbolLibCache"]

--- a/src/circuit_synth/kicad/bom_manager.py
+++ b/src/circuit_synth/kicad/bom_manager.py
@@ -1,0 +1,295 @@
+"""BOM Property Management for Circuit-Synth.
+
+High-level interface for managing Bill of Materials properties in KiCad schematics.
+Wraps kicad-sch-api BOM functionality with circuit-synth conventions.
+"""
+
+import logging
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+from kicad_sch_api.bom import BOMPropertyAuditor, ComponentIssue, PropertyMatcher
+
+logger = logging.getLogger(__name__)
+
+
+class BOMPropertyManager:
+    """
+    Manage BOM properties for KiCad schematics.
+
+    High-level interface for auditing, updating, and transforming component
+    properties across schematics. Useful for BOM cleanup and standardization.
+
+    Example:
+        >>> manager = BOMPropertyManager()
+        >>>
+        >>> # Audit for missing properties
+        >>> issues = manager.audit_directory(
+        ...     Path("~/my_designs"),
+        ...     required_properties=["PartNumber", "Manufacturer"]
+        ... )
+        >>>
+        >>> # Generate report
+        >>> manager.generate_report(issues, Path("audit.csv"))
+        >>>
+        >>> # Bulk update properties
+        >>> manager.update_properties(
+        ...     Path("~/my_designs"),
+        ...     match={"value": "10k", "lib_id": "Device:R"},
+        ...     set_properties={"PartNumber": "RC0805FR-0710KL"}
+        ... )
+    """
+
+    def __init__(self):
+        """Initialize BOM property manager."""
+        self.auditor = BOMPropertyAuditor()
+        logger.debug("BOMPropertyManager initialized")
+
+    def audit_directory(
+        self,
+        directory: Path,
+        required_properties: List[str],
+        recursive: bool = True,
+        exclude_dnp: bool = False,
+    ) -> List[ComponentIssue]:
+        """
+        Audit directory for components missing required properties.
+
+        Args:
+            directory: Path to directory containing .kicad_sch files
+            required_properties: List of property names that must be present
+            recursive: Scan subdirectories (default: True)
+            exclude_dnp: Skip Do-Not-Populate components (default: False)
+
+        Returns:
+            List of ComponentIssue objects describing missing properties
+
+        Example:
+            >>> manager = BOMPropertyManager()
+            >>> issues = manager.audit_directory(
+            ...     Path("~/designs"),
+            ...     required_properties=["PartNumber", "Manufacturer"],
+            ...     exclude_dnp=True
+            ... )
+            >>> print(f"Found {len(issues)} components with missing properties")
+        """
+        logger.info(
+            f"Auditing directory: {directory} for properties: {required_properties}"
+        )
+
+        issues = self.auditor.audit_directory(
+            directory=directory,
+            required_properties=required_properties,
+            recursive=recursive,
+            exclude_dnp=exclude_dnp,
+        )
+
+        logger.info(f"Audit complete: found {len(issues)} components with missing properties")
+        return issues
+
+    def audit_schematic(
+        self,
+        schematic_path: Path,
+        required_properties: List[str],
+        exclude_dnp: bool = False,
+    ) -> List[ComponentIssue]:
+        """
+        Audit single schematic for missing properties.
+
+        Args:
+            schematic_path: Path to .kicad_sch file
+            required_properties: List of property names that must be present
+            exclude_dnp: Skip Do-Not-Populate components (default: False)
+
+        Returns:
+            List of ComponentIssue objects
+
+        Example:
+            >>> manager = BOMPropertyManager()
+            >>> issues = manager.audit_schematic(
+            ...     Path("circuit.kicad_sch"),
+            ...     required_properties=["PartNumber"]
+            ... )
+        """
+        logger.debug(f"Auditing schematic: {schematic_path}")
+
+        issues = self.auditor.audit_schematic(
+            schematic_path=schematic_path,
+            required_properties=required_properties,
+            exclude_dnp=exclude_dnp,
+        )
+
+        logger.debug(f"Found {len(issues)} components with missing properties")
+        return issues
+
+    def generate_report(
+        self, issues: List[ComponentIssue], output_path: Path
+    ) -> None:
+        """
+        Generate CSV report from audit results.
+
+        Args:
+            issues: List of ComponentIssue objects from audit
+            output_path: Path where CSV report should be saved
+
+        Example:
+            >>> manager = BOMPropertyManager()
+            >>> issues = manager.audit_directory(Path("~/designs"), ["PartNumber"])
+            >>> manager.generate_report(issues, Path("audit_report.csv"))
+        """
+        logger.info(f"Generating audit report: {output_path}")
+        self.auditor.generate_csv_report(issues, output_path)
+        logger.info(f"Report saved: {output_path}")
+
+    def update_properties(
+        self,
+        directory: Path,
+        match: Dict[str, str],
+        set_properties: Dict[str, str],
+        dry_run: bool = False,
+        recursive: bool = True,
+        exclude_dnp: bool = False,
+    ) -> int:
+        """
+        Bulk update properties on matching components.
+
+        Args:
+            directory: Path to directory containing .kicad_sch files
+            match: Dict of field=pattern criteria (all must match)
+            set_properties: Dict of property=value updates to apply
+            dry_run: Preview only, don't modify files (default: False)
+            recursive: Scan subdirectories (default: True)
+            exclude_dnp: Skip Do-Not-Populate components (default: False)
+
+        Returns:
+            Number of components updated
+
+        Example:
+            >>> manager = BOMPropertyManager()
+            >>>
+            >>> # Preview update
+            >>> count = manager.update_properties(
+            ...     Path("~/designs"),
+            ...     match={"value": "10k", "lib_id": "Device:R"},
+            ...     set_properties={"PartNumber": "RC0805FR-0710KL"},
+            ...     dry_run=True
+            ... )
+            >>> print(f"Would update {count} components")
+            >>>
+            >>> # Apply update
+            >>> count = manager.update_properties(
+            ...     Path("~/designs"),
+            ...     match={"value": "10k", "lib_id": "Device:R"},
+            ...     set_properties={
+            ...         "PartNumber": "RC0805FR-0710KL",
+            ...         "Manufacturer": "Yageo",
+            ...         "Tolerance": "1%"
+            ...     }
+            ... )
+        """
+        action = "Would update" if dry_run else "Updating"
+        logger.info(
+            f"{action} components matching {match} with properties {set_properties}"
+        )
+
+        count = self.auditor.update_properties(
+            directory=directory,
+            match_criteria=match,
+            property_updates=set_properties,
+            dry_run=dry_run,
+            recursive=recursive,
+            exclude_dnp=exclude_dnp,
+        )
+
+        logger.info(f"{action} {count} components")
+        return count
+
+    def transform_properties(
+        self,
+        directory: Path,
+        transformations: List[Tuple[str, str]],
+        only_if_empty: bool = False,
+        dry_run: bool = False,
+        recursive: bool = True,
+        exclude_dnp: bool = False,
+    ) -> int:
+        """
+        Copy or rename properties across components.
+
+        Args:
+            directory: Path to directory containing .kicad_sch files
+            transformations: List of (source_property, dest_property) tuples
+            only_if_empty: Only copy to empty destination properties (default: False)
+            dry_run: Preview only, don't modify files (default: False)
+            recursive: Scan subdirectories (default: True)
+            exclude_dnp: Skip Do-Not-Populate components (default: False)
+
+        Returns:
+            Number of components transformed
+
+        Example:
+            >>> manager = BOMPropertyManager()
+            >>>
+            >>> # Copy MPN to PartNumber (only where PartNumber is empty)
+            >>> count = manager.transform_properties(
+            ...     Path("~/designs"),
+            ...     transformations=[("MPN", "PartNumber")],
+            ...     only_if_empty=True
+            ... )
+            >>>
+            >>> # Rename property (overwrite existing)
+            >>> count = manager.transform_properties(
+            ...     Path("~/designs"),
+            ...     transformations=[("OldField", "NewField")]
+            ... )
+        """
+        action = "Would transform" if dry_run else "Transforming"
+        logger.info(
+            f"{action} properties: {transformations} (only_if_empty={only_if_empty})"
+        )
+
+        count = self.auditor.transform_properties(
+            directory=directory,
+            transformations=transformations,
+            only_if_empty=only_if_empty,
+            dry_run=dry_run,
+            recursive=recursive,
+            exclude_dnp=exclude_dnp,
+        )
+
+        logger.info(f"{action} {count} components")
+        return count
+
+    @staticmethod
+    def parse_match_criteria(criteria_str: str) -> Dict[str, str]:
+        """
+        Parse criteria string into dict for matching.
+
+        Args:
+            criteria_str: Comma-separated criteria (e.g., "value=10k,lib_id=Device:R")
+
+        Returns:
+            Dict of field=pattern criteria
+
+        Example:
+            >>> criteria = BOMPropertyManager.parse_match_criteria("value=10k,footprint=*0805*")
+            >>> # Returns: {"value": "10k", "footprint": "*0805*"}
+        """
+        return PropertyMatcher.parse_criteria(criteria_str)
+
+    @staticmethod
+    def parse_properties(props_str: str) -> Dict[str, str]:
+        """
+        Parse property string into dict for setting.
+
+        Args:
+            props_str: Comma-separated properties (e.g., "PartNumber=XXX,Manufacturer=YYY")
+
+        Returns:
+            Dict of property=value pairs
+
+        Example:
+            >>> props = BOMPropertyManager.parse_properties("PartNumber=XXX,Manufacturer=YYY")
+            >>> # Returns: {"PartNumber": "XXX", "Manufacturer": "YYY"}
+        """
+        return PropertyMatcher.parse_criteria(props_str)

--- a/tests/kicad/test_bom_manager.py
+++ b/tests/kicad/test_bom_manager.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+"""
+Tests for BOM Property Manager.
+
+Tests the circuit-synth wrapper around kicad-sch-api BOM functionality.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# Add to path
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+import kicad_sch_api as ksa
+from circuit_synth.kicad.bom_manager import BOMPropertyManager
+
+
+def get_property_value(component, prop_name):
+    """Helper to extract property value, handling both str and dict returns."""
+    prop = component.get_property(prop_name)
+    if prop is None:
+        return None
+    if isinstance(prop, dict):
+        return prop.get("value")
+    return prop
+
+
+@pytest.fixture
+def test_fixtures_dir(tmp_path):
+    """Create test fixtures on-the-fly for each test."""
+    fixtures_dir = tmp_path / "bom_manager_test"
+    fixtures_dir.mkdir()
+
+    # 1. Perfect compliance schematic (all have PartNumber)
+    perfect = ksa.create_schematic("PerfectCompliance")
+    r1 = perfect.components.add("Device:R", "R1", "10k", position=(100, 100))
+    r1.set_property("PartNumber", "RC0805FR-0710KL")
+    r1.set_property("Manufacturer", "Yageo")
+    perfect.save(str(fixtures_dir / "perfect.kicad_sch"))
+
+    # 2. No compliance schematic (none have PartNumber)
+    missing = ksa.create_schematic("MissingPartNumbers")
+    missing.components.add("Device:R", "R1", "10k", position=(100, 100))
+    missing.components.add("Device:R", "R2", "100k", position=(100, 120))
+    missing.components.add("Device:C", "C1", "100nF", position=(120, 100))
+    missing.save(str(fixtures_dir / "missing.kicad_sch"))
+
+    # 3. Mixed compliance (some have, some don't)
+    mixed = ksa.create_schematic("MixedCompliance")
+    r1 = mixed.components.add("Device:R", "R1", "10k", position=(100, 100))
+    r1.set_property("PartNumber", "RC0805FR-0710KL")
+    mixed.components.add("Device:R", "R2", "100k", position=(100, 120))  # No PartNumber
+    c1 = mixed.components.add("Device:C", "C1", "100nF", position=(120, 100))
+    c1.set_property("PartNumber", "GRM123456")
+    mixed.save(str(fixtures_dir / "mixed.kicad_sch"))
+
+    # 4. Test with MPN property (for transform tests)
+    with_mpn = ksa.create_schematic("WithMPN")
+    r1 = with_mpn.components.add("Device:R", "R1", "10k", position=(100, 100))
+    r1.set_property("MPN", "MPN123")  # Has MPN but not PartNumber
+    with_mpn.save(str(fixtures_dir / "with_mpn.kicad_sch"))
+
+    return fixtures_dir
+
+
+class TestBOMPropertyManager:
+    """Test BOMPropertyManager class."""
+
+    def test_initialization(self):
+        """Should initialize successfully."""
+        manager = BOMPropertyManager()
+        assert manager is not None
+        assert manager.auditor is not None
+
+    def test_audit_directory(self, test_fixtures_dir):
+        """Should audit directory for missing properties."""
+        manager = BOMPropertyManager()
+
+        issues = manager.audit_directory(
+            test_fixtures_dir, required_properties=["PartNumber"], recursive=False
+        )
+
+        # Should find at least 5 components missing PartNumber
+        assert len(issues) >= 5
+
+    def test_audit_schematic(self, test_fixtures_dir):
+        """Should audit single schematic."""
+        manager = BOMPropertyManager()
+
+        # Perfect compliance
+        issues = manager.audit_schematic(
+            test_fixtures_dir / "perfect.kicad_sch", required_properties=["PartNumber"]
+        )
+        assert len(issues) == 0
+
+        # Missing compliance
+        issues = manager.audit_schematic(
+            test_fixtures_dir / "missing.kicad_sch", required_properties=["PartNumber"]
+        )
+        assert len(issues) == 3
+
+    def test_generate_report(self, test_fixtures_dir, tmp_path):
+        """Should generate CSV report."""
+        manager = BOMPropertyManager()
+
+        issues = manager.audit_directory(
+            test_fixtures_dir, required_properties=["PartNumber"], recursive=False
+        )
+
+        report_path = tmp_path / "test_report.csv"
+        manager.generate_report(issues, report_path)
+
+        assert report_path.exists()
+
+        # Verify CSV content
+        content = report_path.read_text()
+        assert "Schematic" in content
+        assert "Reference" in content
+
+    def test_update_properties_dry_run(self, test_fixtures_dir):
+        """Should preview updates in dry-run mode."""
+        manager = BOMPropertyManager()
+
+        count = manager.update_properties(
+            test_fixtures_dir,
+            match={"value": "10k", "lib_id": "Device:R"},
+            set_properties={"PartNumber": "TEST123"},
+            dry_run=True,
+            recursive=False,
+        )
+
+        # Should find matching components
+        assert count > 0
+
+        # Verify no actual changes (dry-run)
+        sch = ksa.Schematic.load(str(test_fixtures_dir / "missing.kicad_sch"))
+        for comp in sch.components:
+            if comp.reference == "R1" and comp.value == "10k":
+                assert get_property_value(comp, "PartNumber") is None
+
+    def test_update_properties_actual(self, test_fixtures_dir):
+        """Should actually update properties."""
+        manager = BOMPropertyManager()
+
+        count = manager.update_properties(
+            test_fixtures_dir,
+            match={"reference": "R1", "value": "10k"},
+            set_properties={"TestProperty": "TestValue123"},
+            dry_run=False,
+            recursive=False,
+        )
+
+        assert count > 0
+
+        # Verify actual changes
+        sch = ksa.Schematic.load(str(test_fixtures_dir / "missing.kicad_sch"))
+        for comp in sch.components:
+            if comp.reference == "R1" and comp.value == "10k":
+                assert get_property_value(comp, "TestProperty") == "TestValue123"
+
+    def test_update_multiple_properties(self, test_fixtures_dir):
+        """Should update multiple properties at once."""
+        manager = BOMPropertyManager()
+
+        count = manager.update_properties(
+            test_fixtures_dir,
+            match={"value": "10k"},
+            set_properties={
+                "PartNumber": "XXX",
+                "Manufacturer": "YYY",
+                "Tolerance": "1%",
+            },
+            dry_run=True,
+            recursive=False,
+        )
+
+        assert count > 0
+
+    def test_transform_properties(self, test_fixtures_dir):
+        """Should transform properties successfully."""
+        manager = BOMPropertyManager()
+
+        # Run transform to copy MPN to PartNumber
+        count = manager.transform_properties(
+            test_fixtures_dir,
+            transformations=[("MPN", "PartNumber")],
+            only_if_empty=False,
+            dry_run=False,
+            recursive=False,
+        )
+
+        assert count > 0
+
+        # Verify transformation happened
+        sch = ksa.Schematic.load(str(test_fixtures_dir / "with_mpn.kicad_sch"))
+        for comp in sch.components:
+            if comp.reference == "R1":
+                assert get_property_value(comp, "PartNumber") == "MPN123"
+
+    def test_transform_only_if_empty(self, test_fixtures_dir):
+        """Should respect only_if_empty flag."""
+        manager = BOMPropertyManager()
+
+        # Set both MPN and PartNumber
+        test_sch = test_fixtures_dir / "mixed.kicad_sch"
+        sch = ksa.Schematic.load(str(test_sch))
+        for comp in sch.components:
+            if comp.reference == "R1":
+                comp.set_property("MPN", "NEW_MPN_VALUE")
+                break
+        sch.save(str(test_sch))
+
+        # Transform with only_if_empty
+        count = manager.transform_properties(
+            test_fixtures_dir,
+            transformations=[("MPN", "PartNumber")],
+            only_if_empty=True,
+            dry_run=False,
+            recursive=False,
+        )
+
+        # Verify PartNumber was NOT overwritten
+        sch = ksa.Schematic.load(str(test_sch))
+        for comp in sch.components:
+            if comp.reference == "R1":
+                # Should still have original PartNumber
+                assert get_property_value(comp, "PartNumber") == "RC0805FR-0710KL"
+                assert get_property_value(comp, "MPN") == "NEW_MPN_VALUE"
+
+    def test_parse_match_criteria(self):
+        """Should parse match criteria string."""
+        criteria = BOMPropertyManager.parse_match_criteria(
+            "value=10k,footprint=*0805*"
+        )
+        assert criteria == {"value": "10k", "footprint": "*0805*"}
+
+    def test_parse_properties(self):
+        """Should parse property string."""
+        props = BOMPropertyManager.parse_properties("PartNumber=XXX,Manufacturer=YYY")
+        assert props == {"PartNumber": "XXX", "Manufacturer": "YYY"}
+
+    def test_exclude_dnp(self, test_fixtures_dir):
+        """Should exclude DNP components when requested."""
+        # Create schematic with DNP component
+        dnp_sch = ksa.create_schematic("WithDNP")
+        r1 = dnp_sch.components.add("Device:R", "R1", "10k", position=(100, 100))
+        r1.set_property("PartNumber", "RC0805FR-0710KL")
+        r2 = dnp_sch.components.add("Device:R", "R2", "100k", position=(100, 120))
+        r2.set_property("dnp", "1")  # DNP component without PartNumber
+        dnp_sch.save(str(test_fixtures_dir / "with_dnp.kicad_sch"))
+
+        manager = BOMPropertyManager()
+
+        # Without exclude_dnp
+        issues_with_dnp = manager.audit_schematic(
+            test_fixtures_dir / "with_dnp.kicad_sch",
+            required_properties=["PartNumber"],
+            exclude_dnp=False,
+        )
+
+        # With exclude_dnp
+        issues_without_dnp = manager.audit_schematic(
+            test_fixtures_dir / "with_dnp.kicad_sch",
+            required_properties=["PartNumber"],
+            exclude_dnp=True,
+        )
+
+        # Should find DNP component without exclude flag
+        assert len(issues_with_dnp) > len(issues_without_dnp)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Add high-level BOM property management wrapper around kicad-sch-api BOM functionality.

Provides circuit-synth-style API for managing component properties in KiCad schematics for manufacturing compliance.

## Features

- BOMPropertyManager class wrapping kicad-sch-api BOM module
- Audit schematics for missing properties (PartNumber, Manufacturer, etc.)
- Generate CSV reports for manual review
- Bulk property updates with pattern matching
- Property transformation (copy/rename) capabilities
- DNP (Do-Not-Populate) filtering for production BOMs
- Comprehensive test suite

## Example Usage

```python
from circuit_synth.kicad import BOMPropertyManager
from pathlib import Path

manager = BOMPropertyManager()

# Audit for missing properties
issues = manager.audit_directory(
    Path("designs"),
    required_properties=["PartNumber", "Manufacturer"],
    exclude_dnp=True
)

# Generate CSV report
manager.generate_report(issues, Path("audit.csv"))

# Bulk update properties
manager.update_properties(
    Path("designs"),
    match={"value": "10k", "lib_id": "Device:R"},
    set_properties={
        "PartNumber": "RC0805FR-0710KL",
        "Manufacturer": "Yageo",
        "Tolerance": "1%"
    }
)

# Transform properties
manager.transform_properties(
    Path("designs"),
    transformations=[("MPN", "PartNumber")],
    only_if_empty=True
)
```

## Testing

- Complete test suite in tests/kicad/test_bom_manager.py
- Tests cover all core functionality
- Fixture-based testing with temporary schematics

## Documentation

- Updated README to mention BOM property management
- API documentation in code docstrings
- Examples in test file

## Dependencies

Requires kicad-sch-api with BOM module (merged in circuit-synth/kicad-sch-api#186)

Generated with Claude Code
