### PR TITLE
fix: Correct import paths in project setup tools (#588)

### DIFF
--- a/src/circuit_synth/tools/project_management/init_existing_project.py
+++ b/src/circuit_synth/tools/project_management/init_existing_project.py
@@ -25,9 +25,9 @@ from rich.prompt import Confirm, Prompt
 from rich.text import Text
 
 # Import existing circuit-synth modules
-from circuit_synth.ai_integration.claude.agent_registry import register_circuit_agents
+from circuit_synth.ai_integration.claude import register_circuit_agents
 from circuit_synth.core.kicad_validator import validate_kicad_installation
-from circuit_synth.tools.kicad_parser import KiCadParser
+from circuit_synth.tools.utilities.kicad_parser import KiCadParser
 
 console = Console()
 

--- a/src/circuit_synth/tools/project_management/new_project.py
+++ b/src/circuit_synth/tools/project_management/new_project.py
@@ -24,7 +24,7 @@ from rich.prompt import Confirm
 from rich.text import Text
 
 # Import circuit-synth modules
-from circuit_synth.ai_integration.claude.agent_registry import register_circuit_agents
+from circuit_synth.ai_integration.claude import register_circuit_agents
 from circuit_synth.core.kicad_validator import validate_kicad_installation
 
 # Import new interactive CLI modules

--- a/tests/unit/tools/project_management/test_new_project.py
+++ b/tests/unit/tools/project_management/test_new_project.py
@@ -498,3 +498,80 @@ class TestEdgeCases:
 
                 # Should fall back to register_circuit_agents
                 assert mock_register.called, "Should call fallback agent registration"
+
+
+# ============================================================================
+# Import Regression Tests (#588)
+# ============================================================================
+
+
+class TestModuleImports:
+    """
+    Regression tests for module import issues.
+
+    These tests verify that all project management tools can be imported
+    without ModuleNotFoundError, preventing regressions like issue #588.
+    """
+
+    def test_new_project_module_imports(self):
+        """
+        REGRESSION TEST for issue #588
+
+        Verifies that new_project.py can be imported without errors.
+        The bug was importing from non-existent agent_registry submodule
+        instead of using the package root with fallback.
+        """
+        # This import should not raise ModuleNotFoundError
+        from circuit_synth.tools.project_management import new_project
+
+        # Verify key functions are accessible
+        assert hasattr(new_project, "main"), "main function should be accessible"
+        assert hasattr(
+            new_project, "create_claude_directory_from_templates"
+        ), "create_claude_directory_from_templates should be accessible"
+
+    def test_init_existing_project_module_imports(self):
+        """
+        REGRESSION TEST for issue #588
+
+        Verifies that init_existing_project.py can be imported without errors.
+        The bug was:
+        1. Importing from non-existent agent_registry submodule
+        2. Wrong import path for KiCadParser
+        """
+        # This import should not raise ModuleNotFoundError
+        from circuit_synth.tools.project_management import init_existing_project
+
+        # Verify key functions are accessible
+        assert hasattr(
+            init_existing_project, "main"
+        ), "main function should be accessible"
+
+    def test_register_circuit_agents_fallback(self):
+        """
+        REGRESSION TEST for issue #588
+
+        Verifies that register_circuit_agents can be imported from package root
+        and provides fallback behavior when agent_registry module is missing.
+        """
+        # This import should work (package root with fallback)
+        from circuit_synth.ai_integration.claude import register_circuit_agents
+
+        # Function should be callable
+        assert callable(
+            register_circuit_agents
+        ), "register_circuit_agents should be callable"
+
+    def test_kicad_parser_import_path(self):
+        """
+        REGRESSION TEST for issue #588
+
+        Verifies KiCadParser can be imported from correct path.
+        The bug was importing from circuit_synth.tools.kicad_parser
+        instead of circuit_synth.tools.utilities.kicad_parser.
+        """
+        # This import should work
+        from circuit_synth.tools.utilities.kicad_parser import KiCadParser
+
+        # Class should be importable
+        assert KiCadParser is not None, "KiCadParser class should be importable"


### PR DESCRIPTION
## Summary
- Fix `ModuleNotFoundError` when running `cs-new-project` and `cs-init-existing-project`
- Change `agent_registry` import to use package root with graceful fallback
- Fix `KiCadParser` import path (`tools.kicad_parser` → `tools.utilities.kicad_parser`)

## Root Cause
The project setup tools were importing from `circuit_synth.ai_integration.claude.agent_registry`, but this module doesn't exist. The `__init__.py` has a fallback implementation that handles the missing module gracefully, so the fix is to import from the package root instead.

## Test Plan
- [x] Added 4 regression tests in `TestModuleImports` class
- [x] `test_new_project_module_imports` - verifies new_project.py imports
- [x] `test_init_existing_project_module_imports` - verifies init_existing_project.py imports
- [x] `test_register_circuit_agents_fallback` - verifies fallback works
- [x] `test_kicad_parser_import_path` - verifies correct import path
- [x] All 27 tests in test_new_project.py pass
- [x] `uv run cs-new-project --help` works correctly

Closes #588

🤖 Generated with [Claude Code](https://claude.com/claude-code)