### PR TITLE
fix: Fix Windows cp1252 encoding errors in cs-new-project

### DIFF
--- a/src/circuit_synth/tools/project_management/new_project.py
+++ b/src/circuit_synth/tools/project_management/new_project.py
@@ -32,7 +32,15 @@ from .interactive_cli import parse_cli_flags, run_interactive_setup
 from .project_config import get_default_config
 from .template_manager import CLAUDEMDGenerator, READMEGenerator, TemplateManager
 
-console = Console()
+# Force UTF-8 output on Windows to avoid cp1252 encoding errors with emoji
+if sys.platform == "win32":
+    try:
+        sys.stdout.reconfigure(encoding="utf-8")
+        sys.stderr.reconfigure(encoding="utf-8")
+    except Exception:
+        pass
+
+console = Console(force_terminal=False)
 
 
 def create_claude_directory_from_templates(
@@ -963,12 +971,12 @@ def main(
 
     readme_content = readme_gen.generate(config, project_path)
     readme_path = project_path / "README.md"
-    readme_path.write_text(readme_content)
+    readme_path.write_text(readme_content, encoding="utf-8")
     console.print("✅ Created README.md", style="green")
 
     claude_md_content = claude_md_gen.generate(config)
     claude_md_path = project_path / "CLAUDE.md"
-    claude_md_path.write_text(claude_md_content)
+    claude_md_path.write_text(claude_md_content, encoding="utf-8")
     console.print("✅ Created CLAUDE.md", style="green")
 
     # Step 8: KiCad plugins note (if KiCad is installed)

--- a/src/circuit_synth/tools/project_management/template_manager.py
+++ b/src/circuit_synth/tools/project_management/template_manager.py
@@ -43,7 +43,7 @@ class TemplateManager:
                 f"Expected location: {template_dir}"
             )
 
-        return template_file.read_text()
+        return template_file.read_text(encoding="utf-8")
 
     def copy_circuit_to_project(
         self, circuit: Circuit, project_path: Path, is_first: bool = False
@@ -69,7 +69,7 @@ class TemplateManager:
 
         # Write the circuit file
         target_file = circuit_dir / target_filename
-        target_file.write_text(circuit_code)
+        target_file.write_text(circuit_code, encoding="utf-8")
 
     def list_available_circuits(self) -> list[Circuit]:
         """Get list of all available circuits


### PR DESCRIPTION
## Summary

- On Windows (Git Bash), `cs-new-project` crashes with `UnicodeEncodeError` because Rich tries to output emoji characters (⚡, ✅, etc.) through a cp1252-encoded console
- Template files containing UTF-8 characters also fail to load/write due to `read_text()`/`write_text()` defaulting to cp1252 on Windows

### Changes

- **`new_project.py`**: Force `sys.stdout`/`sys.stderr` to UTF-8 on Windows before Rich Console initialization
- **`template_manager.py`**: Add explicit `encoding="utf-8"` to `read_text()` and `write_text()` calls
- **`new_project.py`**: Same `encoding="utf-8"` fix for README.md and CLAUDE.md generation

## Test plan

- [x] Verified `uv run cs-new-project --quick --skip-kicad-check` succeeds on Windows 11 with Git Bash
- [ ] Verify no regression on Linux/macOS (the `sys.platform` guard ensures the reconfigure only runs on Windows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)