### PR TITLE
Fix Windows crashes in project and schematic generation

### DIFF
--- a/src/circuit_synth/kicad/sch_gen/schematic_writer.py
+++ b/src/circuit_synth/kicad/sch_gen/schematic_writer.py
@@ -410,8 +410,6 @@ class SchematicWriter:
 
         PERFORMANCE MONITORING: Times each major operation.
         """
-        with open("/tmp/circuit_synth_debug.log", "a") as f:
-            f.write(f"generate_s_expr called for circuit {self.circuit.name}\n")
         start_time = time.perf_counter()
         logger.info(
             f"🚀 GENERATE_S_EXPR: Starting schematic generation for circuit '{self.circuit.name}'"

--- a/src/circuit_synth/tools/project_management/new_project.py
+++ b/src/circuit_synth/tools/project_management/new_project.py
@@ -963,12 +963,12 @@ def main(
 
     readme_content = readme_gen.generate(config, project_path)
     readme_path = project_path / "README.md"
-    readme_path.write_text(readme_content)
+    readme_path.write_text(readme_content, encoding="utf-8")
     console.print("✅ Created README.md", style="green")
 
     claude_md_content = claude_md_gen.generate(config)
     claude_md_path = project_path / "CLAUDE.md"
-    claude_md_path.write_text(claude_md_content)
+    claude_md_path.write_text(claude_md_content, encoding="utf-8")
     console.print("✅ Created CLAUDE.md", style="green")
 
     # Step 8: KiCad plugins note (if KiCad is installed)

--- a/src/circuit_synth/tools/project_management/template_manager.py
+++ b/src/circuit_synth/tools/project_management/template_manager.py
@@ -43,7 +43,7 @@ class TemplateManager:
                 f"Expected location: {template_dir}"
             )
 
-        return template_file.read_text()
+        return template_file.read_text(encoding="utf-8")
 
     def copy_circuit_to_project(
         self, circuit: Circuit, project_path: Path, is_first: bool = False
@@ -69,7 +69,7 @@ class TemplateManager:
 
         # Write the circuit file
         target_file = circuit_dir / target_filename
-        target_file.write_text(circuit_code)
+        target_file.write_text(circuit_code, encoding="utf-8")
 
     def list_available_circuits(self) -> list[Circuit]:
         """Get list of all available circuits


### PR DESCRIPTION
## Summary

Fixes two platform-default bugs that prevent circuit-synth from running on Windows. Both stem from relying on OS defaults (Python's legacy `cp1252` codec and a hardcoded POSIX `/tmp` path) instead of being explicit.

I hit these going through the [Get Started](https://www.circuit-synth.com/#get-started) flow on Windows 11 with KiCad 10.0.3 — `cs-new-project` crashed during project creation, and schematic generation crashed on `main`.

## Changes

### 1. `cs-new-project` crash — `UnicodeDecodeError`/`UnicodeEncodeError` (cp1252)
`template_manager.py` and `new_project.py` read/write project files without specifying an encoding, so Python uses the OS default. On Windows that's `cp1252`, which can't handle the non-Latin-1 characters in the templates and generated docs (e.g. emoji in the STM32 template and `CLAUDE.md`):

```
UnicodeDecodeError: 'charmap' codec can't decode byte 0x81 in position 4968: character maps to <undefined>
```

Fix: pass `encoding="utf-8"` to the `read_text()` / `write_text()` calls (4 call sites).

### 2. Schematic generation crash — hardcoded `/tmp` path (Windows)
`schematic_writer.py` opens `"/tmp/circuit_synth_debug.log"` for append at the very top of `generate_s_expr()`. On Windows `/tmp` doesn't exist, so this raises `FileNotFoundError` and aborts schematic generation before it starts. The same information is already logged via `logger.info(...)`, so this is leftover debug instrumentation — removed.

## Why this matters beyond the immediate crash

When schematic generation fails partway, it can leave a 0-byte `.kicad_sch` behind. On the next run, circuit-synth detects an "existing project," switches to update mode, fails to parse the empty file (`Invalid S-expression format`), and aborts to preserve it — trapping the user in a loop. Fixing the `/tmp` crash removes one way that broken state is created on Windows.

## Testing

On Windows 11 (ARM64) + Python 3.14 + KiCad 10.0.3, after these changes:

- `uv run cs-new-project` completes and writes the project, `README.md`, and `CLAUDE.md`.
- `uv run python circuit-synth/main.py` completes and produces a valid ~76 KB `STM32_Minimal.kicad_sch`, `.net`, and PDF.
- All three changed files pass `python -m py_compile`.

## Notes / out of scope

- The update-mode abort on an empty/invalid existing `.kicad_sch` is a separate robustness issue (could fall back to fresh generation); happy to follow up if maintainers want it.
- KiCad detection still only scans `C:\Program Files\KiCad\7.0|8.0`; per-user installs and KiCad 9/10 aren't auto-detected (worked around via PATH + `KICAD_SYMBOL_DIR`). Also a candidate for a follow-up.
