### PR TITLE
fix: schematic generation — symbol bbox, multi-unit placement, internal/local labels

### DIFF
--- a/src/circuit_synth/kicad/sch_gen/circuit_loader.py
+++ b/src/circuit_synth/kicad/sch_gen/circuit_loader.py
@@ -279,30 +279,22 @@ def _parse_circuit(circ_data: dict, sub_dict: Dict[str, Circuit]) -> Circuit:
             comp_ref = conn["component"]
             pin_data = conn["pin"]
 
-            # Enhanced pin identification - store the most specific identifier available
+            # Pin identification for label placement. Use the pin NUMBER first:
+            # it is unique per component, whereas a NAME is shared by every pin
+            # of the same function (VDD/VDDQ, OUT, PGND, ...). Resolving by name
+            # makes find_pin_by_identifier() return the first match, so all those
+            # pins collapse onto one coordinate and only one gets a label/wire —
+            # the rest float. The number keeps each physical pin distinct.
             pin_identifier = None
-
-            # First check if name is available (most specific).
-            # An empty name ("") is NOT specific: passives such as Device:C have
-            # two pins both named "" and resolving by name would collapse them
-            # onto the first pin. Fall through to the pin number in that case.
-            if "name" in pin_data and pin_data["name"] not in ("~", ""):
-                pin_identifier = pin_data["name"]
-                logger.debug(
-                    f"Using pin name '{pin_identifier}' for {comp_ref} in net {net_name}"
-                )
-            # Then check for number
-            elif "number" in pin_data:
+            if "number" in pin_data and str(pin_data["number"]) not in ("", "~"):
                 pin_identifier = str(pin_data["number"])
-                logger.debug(
-                    f"Using pin number '{pin_identifier}' for {comp_ref} in net {net_name}"
-                )
-            # Finally fall back to pin_id
+            elif "name" in pin_data and pin_data["name"] not in ("~", ""):
+                pin_identifier = pin_data["name"]
             else:
                 pin_identifier = str(pin_data.get("pin_id", ""))
-                logger.debug(
-                    f"Using pin ID '{pin_identifier}' for {comp_ref} in net {net_name}"
-                )
+            logger.debug(
+                f"Using pin id '{pin_identifier}' for {comp_ref} in net {net_name}"
+            )
 
             net_obj.connections.append((comp_ref, pin_identifier))
             logger.debug(

--- a/src/circuit_synth/kicad/sch_gen/circuit_loader.py
+++ b/src/circuit_synth/kicad/sch_gen/circuit_loader.py
@@ -282,8 +282,11 @@ def _parse_circuit(circ_data: dict, sub_dict: Dict[str, Circuit]) -> Circuit:
             # Enhanced pin identification - store the most specific identifier available
             pin_identifier = None
 
-            # First check if name is available (most specific)
-            if "name" in pin_data and pin_data["name"] != "~":
+            # First check if name is available (most specific).
+            # An empty name ("") is NOT specific: passives such as Device:C have
+            # two pins both named "" and resolving by name would collapse them
+            # onto the first pin. Fall through to the pin number in that case.
+            if "name" in pin_data and pin_data["name"] not in ("~", ""):
                 pin_identifier = pin_data["name"]
                 logger.debug(
                     f"Using pin name '{pin_identifier}' for {comp_ref} in net {net_name}"

--- a/src/circuit_synth/kicad/sch_gen/schematic_writer.py
+++ b/src/circuit_synth/kicad/sch_gen/schematic_writer.py
@@ -620,10 +620,18 @@ class SchematicWriter:
                     logger.debug(
                         f"      Adding multi-unit component with {unit_count} units"
                     )
-                    # Add each unit with a vertical offset
-                    unit_spacing = (
-                        12.7  # 0.5 inch (12.7mm) vertical spacing between units
-                    )
+                    # Add each unit with a vertical offset equal to the symbol's
+                    # own height (+margin) so large multi-unit parts (e.g. MCUs)
+                    # don't stack on top of each other.
+                    unit_spacing = 12.7  # fallback: 0.5 inch
+                    try:
+                        _ld = SymbolLibCache.get_symbol_data(comp.lib_id)
+                        _bb = SymbolBoundingBoxCalculator.calculate_bounding_box(
+                            _ld, include_properties=True
+                        )
+                        unit_spacing = max(12.7, (_bb[3] - _bb[1]) + 5.08)
+                    except Exception:
+                        pass
                     for unit_num in range(1, unit_count + 1):
                         unit_position = (
                             comp.position.x,
@@ -886,8 +894,15 @@ class SchematicWriter:
                     )
                     width = max_x - min_x
                     height = max_y - min_y
+                    # Multi-unit symbols stack their units vertically when placed
+                    # (see the add_component loop), so reserve space for every unit
+                    # or units 2..n collide with neighbouring components.
+                    _sym = get_symbol_cache().get_symbol(comp.lib_id)
+                    _ucount = getattr(_sym, "units", 1) if _sym else 1
+                    if _ucount > 1:
+                        height = height * _ucount
                     print(
-                        f"🔍 PLACEMENT: Calculated bbox for {placement_key}: {width:.2f} x {height:.2f} mm",
+                        f"🔍 PLACEMENT: Calculated bbox for {placement_key}: {width:.2f} x {height:.2f} mm ({_ucount} unit(s))",
                         file=sys.stderr,
                         flush=True,
                     )
@@ -1053,50 +1068,43 @@ class SchematicWriter:
         Returns:
             bool: True if net should have hierarchical label, False for local label
         """
-        # TEMPORARY: Always use hierarchical labels for now
-        # We want all labels to be hierarchical until we're ready to differentiate
-        # between local (internal) and hierarchical (cross-circuit) nets.
-        # The logic below is correct but bypassed for now.
-        return True
+        # A net needs a HIERARCHICAL label (and a matching sheet pin) only if it
+        # crosses this sheet's boundary: shared with the parent circuit, or used
+        # by a child circuit. Nets that are purely internal to this sheet get a
+        # plain LOCAL label. This mirrors the sheet-pin logic in
+        # _add_subcircuit_sheets (which only exposes shared nets as pins).
+        #
+        # Matching is by Net-object identity with a name-based fallback, because
+        # circuits are reconstructed from JSON and object identity does not
+        # survive that round-trip.
+        net_name = getattr(net_obj, "name", None)
 
-        # TODO: Enable this logic when ready to support local labels
-        # ============================================================
-        # # Check if shared with parent
-        # parent_circuit = None
-        # for circ_name, circ in self.all_subcircuits.items():
-        #     for child_info in circ.child_instances:
-        #         if child_info["sub_name"] == self.circuit.name:
-        #             parent_circuit = circ
-        #             break
-        #     if parent_circuit:
-        #         break
-        #
-        # if parent_circuit:
-        #     # Check if this Net OBJECT (not name) is used in the parent
-        #     parent_nets = parent_circuit.nets.values() if isinstance(parent_circuit.nets, dict) else parent_circuit.nets
-        #     for parent_net in parent_nets:
-        #         if parent_net is net_obj:  # Same object reference!
-        #             return True
-        #
-        #     # Fallback to name matching (for JSON-loaded circuits)
-        #     parent_net_names = {n.name for n in parent_nets}
-        #     if net_obj.name in parent_net_names:
-        #         return True
-        #
-        # # Check if used by any child circuit
-        # for child_info in self.circuit.child_instances:
-        #     child_circ = self.all_subcircuits[child_info["sub_name"]]
-        #     child_nets = child_circ.nets.values() if isinstance(child_circ.nets, dict) else child_circ.nets
-        #
-        #     for child_net in child_nets:
-        #         # Check object identity
-        #         if child_net is net_obj:
-        #             return True
-        #         # Fallback to name matching
-        #         if child_net.name == net_obj.name:
-        #             return True
-        #
-        # return False
+        def _net_names(circ):
+            if circ is None:
+                return set()
+            nets = circ.nets.values() if isinstance(circ.nets, dict) else circ.nets
+            return {n.name for n in nets}
+
+        # 1) Shared with the parent sheet?
+        for circ in self.all_subcircuits.values():
+            found_parent = False
+            for child_info in getattr(circ, "child_instances", []) or []:
+                if child_info.get("sub_name") == self.circuit.name:
+                    found_parent = True
+                    break
+            if found_parent:
+                if net_name in _net_names(circ):
+                    return True
+                break  # each sheet has exactly one parent
+
+        # 2) Used by a child sheet?
+        for child_info in getattr(self.circuit, "child_instances", []) or []:
+            child_circ = self.all_subcircuits.get(child_info.get("sub_name"))
+            if net_name in _net_names(child_circ):
+                return True
+
+        # Otherwise it is internal to this sheet -> local label.
+        return False
 
     def _add_power_symbol(
         self,
@@ -1463,7 +1471,13 @@ class SchematicWriter:
                     LabelType.HIERARCHICAL if is_hierarchical else LabelType.LOCAL
                 )
 
-                # Create label using the API
+                # Rotation follows global_angle (KiCad convention, already correct
+                # for hierarchical labels). The justify MUST match it: the
+                # local-label serializer otherwise defaults to "left", which makes
+                # 180deg (left-side) labels read back into the component body. Apply
+                # the canonical justify to BOTH label kinds.
+                from ..schematic.label_utils import calculate_hierarchical_label_justify
+                net_label_justify = calculate_hierarchical_label_justify(global_angle)
                 label = Label(
                     uuid=str(uuid_module.uuid4()),
                     position=Point(global_x, global_y),
@@ -1511,6 +1525,7 @@ class SchematicWriter:
                             ),
                             "rotation": label.rotation,
                             "size": label.size,
+                            "justify_h": net_label_justify,
                         }
                         self.schematic._data["labels"].append(label_dict)
 

--- a/src/circuit_synth/kicad/sch_gen/schematic_writer.py
+++ b/src/circuit_synth/kicad/sch_gen/schematic_writer.py
@@ -1085,19 +1085,32 @@ class SchematicWriter:
             nets = circ.nets.values() if isinstance(circ.nets, dict) else circ.nets
             return {n.name for n in nets}
 
-        # 1) Shared with the parent sheet?
+        # Find this sheet's parent circuit (the one whose children include it).
+        parent = None
         for circ in self.all_subcircuits.values():
-            found_parent = False
             for child_info in getattr(circ, "child_instances", []) or []:
                 if child_info.get("sub_name") == self.circuit.name:
-                    found_parent = True
+                    parent = circ
                     break
-            if found_parent:
-                if net_name in _net_names(circ):
-                    return True
-                break  # each sheet has exactly one parent
+            if parent is not None:
+                break
 
-        # 2) Used by a child sheet?
+        if parent is not None:
+            # 1) Shared with the parent sheet?
+            if net_name in _net_names(parent):
+                return True
+            # 2) Shared with a SIBLING sheet (another child of the same parent)?
+            #    A net created in the parent and passed into two children, with no
+            #    parent-sheet component on it, lives only in the children. It still
+            #    must cross between them, so it needs a hierarchical label + sheet
+            #    pin in each child (and matching labels in the parent).
+            for sib in getattr(parent, "child_instances", []) or []:
+                if sib.get("sub_name") == self.circuit.name:
+                    continue
+                if net_name in _net_names(self.all_subcircuits.get(sib.get("sub_name"))):
+                    return True
+
+        # 3) Used by one of this sheet's own children?
         for child_info in getattr(self.circuit, "child_instances", []) or []:
             child_circ = self.all_subcircuits.get(child_info.get("sub_name"))
             if net_name in _net_names(child_circ):
@@ -1576,71 +1589,47 @@ class SchematicWriter:
             internal_net_names = []
 
             # Handle both dict and list forms of .nets
-            child_nets = (
+            child_nets = list(
                 child_circ.nets.values()
                 if isinstance(child_circ.nets, dict)
                 else child_circ.nets
             )
-            parent_nets = (
+            parent_nets = list(
                 self.circuit.nets.values()
                 if isinstance(self.circuit.nets, dict)
                 else self.circuit.nets
             )
 
-            # First try object identity (works when circuits are created directly in Python)
-            for child_net in child_nets:
-                is_shared = False
-                for parent_net in parent_nets:
-                    if parent_net is child_net:  # Same object reference!
-                        is_shared = True
-                        break
+            # A child net is exposed as a sheet pin if it crosses the child's
+            # boundary, i.e. it is shared with the parent OR with a sibling child.
+            # Object identity covers Python-built circuits; name covers JSON-loaded
+            # ones. Sibling sharing matters when a net is created in the parent and
+            # passed into two children with no parent-sheet component on it (it then
+            # lives only in the children but still must connect between them).
+            parent_net_ids = {id(n) for n in parent_nets}
+            parent_net_names = {n.name for n in parent_nets}
 
-                if is_shared:
+            sibling_net_names = set()
+            for sibling_info in self.circuit.child_instances:
+                if sibling_info["sub_name"] == sub_name:
+                    continue
+                sib = self.all_subcircuits.get(sibling_info["sub_name"])
+                if sib is None:
+                    continue
+                sib_nets = sib.nets.values() if isinstance(sib.nets, dict) else sib.nets
+                sibling_net_names.update(n.name for n in sib_nets)
+
+            for child_net in child_nets:
+                if (
+                    id(child_net) in parent_net_ids
+                    or child_net.name in parent_net_names
+                    or child_net.name in sibling_net_names
+                ):
                     shared_net_names.append(child_net.name)
                 else:
                     internal_net_names.append(child_net.name)
 
-            # If object identity found no shared nets but we have nets to check, fall back to name matching
-            # (needed when circuits are loaded from JSON, which creates new Net objects)
-            if not shared_net_names and list(parent_nets) and list(child_nets):
-                shared_net_names = []
-                internal_net_names = []
-
-                parent_net_names_set = {n.name for n in parent_nets}
-                for child_net in child_nets:
-                    if child_net.name in parent_net_names_set:
-                        shared_net_names.append(child_net.name)
-                    else:
-                        internal_net_names.append(child_net.name)
-
-            # Special case: If parent has NO nets, infer shared nets by looking at sibling circuits
-            # Nets that appear in multiple children are likely shared parameters
-            if not list(parent_nets) and list(child_nets):
-                shared_net_names = []
-                internal_net_names = []
-
-                # Collect nets from all sibling circuits
-                sibling_net_names = set()
-                for sibling_info in self.circuit.child_instances:
-                    if (
-                        sibling_info["sub_name"] != sub_name
-                    ):  # Don't include current child
-                        sibling_circ = self.all_subcircuits[sibling_info["sub_name"]]
-                        sibling_nets = (
-                            sibling_circ.nets.values()
-                            if isinstance(sibling_circ.nets, dict)
-                            else sibling_circ.nets
-                        )
-                        sibling_net_names.update(n.name for n in sibling_nets)
-
-                # Nets that appear in both this child AND siblings are likely shared
-                for child_net in child_nets:
-                    if child_net.name in sibling_net_names:
-                        shared_net_names.append(child_net.name)
-                    else:
-                        internal_net_names.append(child_net.name)
-
-            pin_list = sorted(shared_net_names)
+            pin_list = sorted(set(shared_net_names))
 
             # CRITICAL FIX: Also include the parameters from child circuit instances
             # For subcircuits that only contain other subcircuits (no components),

--- a/src/circuit_synth/kicad/schematic/symbol_geometry.py
+++ b/src/circuit_synth/kicad/schematic/symbol_geometry.py
@@ -114,26 +114,26 @@ class SymbolGeometry:
                 x = pin.position.x
                 y = pin.position.y
                 length = pin.length
-                orientation = pin.orientation
+                orientation = pin.rotation  # SchematicPin uses .rotation
 
-            # Calculate pin endpoint
-            if orientation == 0:  # Right
-                end_x = x + length
-                end_y = y
-            elif orientation == 90:  # Up
-                end_x = x
-                end_y = y + length
-            elif orientation == 180:  # Left
-                end_x = x - length
-                end_y = y
-            else:  # 270 - Down
-                end_x = x
-                end_y = y - length
+                # Calculate pin endpoint
+                if orientation == 0:  # Right
+                    end_x = x + length
+                    end_y = y
+                elif orientation == 90:  # Up
+                    end_x = x
+                    end_y = y + length
+                elif orientation == 180:  # Left
+                    end_x = x - length
+                    end_y = y
+                else:  # 270 - Down
+                    end_x = x
+                    end_y = y - length
 
-            min_x = min(min_x, x, end_x)
-            max_x = max(max_x, x, end_x)
-            min_y = min(min_y, y, end_y)
-            max_y = max(max_y, y, end_y)
+                min_x = min(min_x, x, end_x)
+                max_x = max(max_x, x, end_x)
+                min_y = min(min_y, y, end_y)
+                max_y = max(max_y, y, end_y)
 
         # Calculate dimensions
         if min_x == float("inf"):

--- a/src/circuit_synth/kicad/schematic/text_flow_placement.py
+++ b/src/circuit_synth/kicad/schematic/text_flow_placement.py
@@ -49,6 +49,9 @@ class SheetDef:
 SHEET_SIZES = [
     SheetDef("A4", 297.0, 210.0, 12.7, 12.7, 284.48, 165.10),
     SheetDef("A3", 420.0, 297.0, 12.7, 12.7, 407.0, 277.0),
+    SheetDef("A2", 594.0, 420.0, 12.7, 12.7, 581.0, 400.0),
+    SheetDef("A1", 841.0, 594.0, 12.7, 12.7, 828.0, 574.0),
+    SheetDef("A0", 1189.0, 841.0, 12.7, 12.7, 1176.0, 821.0),
 ]
 
 
@@ -110,7 +113,7 @@ class TextFlowPlacer:
 
         # If we get here, even A3 overflowed
         raise ValueError(
-            f"Components do not fit on A3 sheet (largest supported size). "
+            f"Components do not fit on A0 sheet (largest supported size). "
             f"Reduce component count or implement larger sheet support."
         )
 


### PR DESCRIPTION
A batch of independent correctness fixes in hierarchical KiCad schematic generation, found while generating multi-sheet, bus-heavy boards (a dual-core MCU board with FMC SDRAM, eMMC, dual SPI ADCs, etc.). Each is self-contained.

### 1. Component bounding box always fell back to default → everything overlapped
`SymbolGeometry._calculate_symbol_bounds` read `pin.orientation`, but kicad-sch-api's `SchematicPin` exposes `.rotation`. Every bbox calc raised, was caught, and fell back to a tiny default, so the placer piled all components on top of each other. The pin endpoint/bounds math was also indented **outside** the `for pin` loop (only the last pin counted). Both fixed.

### 2. Multi-unit symbols overlapped
Placement reserved only one unit's bbox and stacked units at a fixed 12.7 mm. Tall multi-unit parts (MCUs) overlapped themselves/neighbours. Now placement reserves `height * unit_count` and spaces units by the symbol's own height.

### 3. Internal nets got hierarchical labels
`_is_net_hierarchical` was hardcoded `return True`, so every net became a hierarchical label even when internal to one sheet. Implemented the intended rule (hierarchical only if shared with the parent or used by a child — matching `_add_subcircuit_sheets`); internal nets now get plain local labels.

### 4. Local-label text overlapped the component body
Local labels were emitted without a justify, and the serializer defaults `justify_h="left"`, so left-side (180°) labels read back into the body. Local labels now get `justify_h` from `calculate_hierarchical_label_justify(rotation)`.

### 5. Multi-pin nets only connected one pin (collapsed by pin name)
Net connections were identified by pin **name**, but a name is shared by every pin of the same function (`VDD`/`VDDQ`, `OUT`, `PGND`, ...). `find_pin_by_identifier` returns the first match, so all those pins collapsed onto one coordinate and only one got a label/wire while the rest floated (this also forced symbol authors to stack pins). Now connections are identified by the unique pin **number**, so every physical pin gets its own label and multi-pin nets connect without stacking. (Generalises the earlier empty-name passive fix — `Device:C`/`Device:R` with two `""` pins also worked around this.)

### 6. Placer capped at A3
`SHEET_SIZES` only listed A4/A3, so large symbols (e.g. a ~244 mm-tall STM32H7 BGA) couldn't be placed. Added A2/A1/A0 (KiCad already supports these paper sizes).

---
All verified by generating multi-sheet boards, diffing the exported `kicad-cli` netlist (connectivity unchanged / multi-pin nets now complete), and rasterising the PDFs to confirm placement and label direction.