### PR TITLE
feat: Add JLCPCB component import for LCSC part numbers

### DIFF
--- a/src/circuit_synth/manufacturing/jlcpcb/__init__.py
+++ b/src/circuit_synth/manufacturing/jlcpcb/__init__.py
@@ -7,6 +7,19 @@ web scraping approaches for maximum flexibility.
 """
 
 from .cache import JLCPCBCache, cached_jlcpcb_search, get_jlcpcb_cache
+from .component_import import (
+    JlcComponentImporter,
+    JlcImportError,
+    JlcLookupError,
+    JlcPartNotFoundError,
+    JlcPartSpec,
+    SymbolResolutionError,
+    component_from_search_result,
+    get_component_importer,
+    import_jlc_component,
+    lookup_lcsc_part,
+    normalize_lcsc_part,
+)
 from .fast_search import (
     FastJLCSearch,
     FastSearchResult,
@@ -65,4 +78,16 @@ __all__ = [
     "find_cheapest_jlc",
     "find_most_available_jlc",
     "get_fast_searcher",
+    # Component import
+    "JlcComponentImporter",
+    "JlcPartSpec",
+    "JlcImportError",
+    "JlcLookupError",
+    "JlcPartNotFoundError",
+    "SymbolResolutionError",
+    "import_jlc_component",
+    "component_from_search_result",
+    "lookup_lcsc_part",
+    "normalize_lcsc_part",
+    "get_component_importer",
 ]

--- a/src/circuit_synth/manufacturing/jlcpcb/component_import.py
+++ b/src/circuit_synth/manufacturing/jlcpcb/component_import.py
@@ -1,0 +1,546 @@
+#!/usr/bin/env python3
+"""
+JLCPCB component import for circuit-synth.
+
+Turns a JLCPCB/LCSC catalog entry into a ready-to-use ``circuit_synth.Component``.
+The importer resolves the KiCad symbol, footprint, value and reference prefix for
+a part and attaches the sourcing metadata (LCSC part number, manufacturer part
+number, manufacturer, stock level and basic/extended status) as component
+properties so it is carried through to the netlist and BOM.
+
+Typical use::
+
+    from circuit_synth.manufacturing.jlcpcb import import_jlc_component
+
+    r1 = import_jlc_component("C25804")
+    # Component(symbol="Device:R", value="10K",
+    #           footprint="Resistor_SMD:R_0603_1608Metric", LCSC="C25804", ...)
+
+The lookup path depends on the JLCPCB search layer, which may be unavailable or
+rate limited. Lookup failures raise :class:`JlcLookupError`; the non raising
+helper :func:`lookup_lcsc_part` returns ``None`` instead so callers can fall back
+to a locally specified component.
+"""
+
+import logging
+import re
+from dataclasses import dataclass
+from typing import Any, Dict, List, Mapping, Optional
+
+from ...core.component import Component
+from .fast_search import FastJLCSearch, FastSearchResult, get_fast_searcher
+from .smart_component_finder import SmartComponentFinder
+
+logger = logging.getLogger(__name__)
+
+# LCSC part numbers are the letter C followed by digits, for example "C25804".
+LCSC_PART_PATTERN = re.compile(r"^C\d+$")
+
+# Number of search results inspected when resolving a single part number.
+_LOOKUP_RESULT_LIMIT = 10
+
+
+class JlcImportError(Exception):
+    """Base error for JLCPCB component import failures."""
+
+
+class JlcPartNotFoundError(JlcImportError):
+    """Raised when no catalog entry matches the requested LCSC part number."""
+
+
+class JlcLookupError(JlcImportError):
+    """Raised when the JLCPCB search layer could not be queried."""
+
+
+class SymbolResolutionError(JlcImportError):
+    """Raised when no KiCad symbol could be determined for a part."""
+
+
+def normalize_lcsc_part(lcsc_part: str) -> str:
+    """
+    Normalize an LCSC part number to its canonical form.
+
+    Args:
+        lcsc_part: LCSC part number, for example "c25804" or " C25804 ".
+
+    Returns:
+        The part number in canonical upper case form, for example "C25804".
+
+    Raises:
+        JlcImportError: If the value is not a valid LCSC part number.
+    """
+    if not isinstance(lcsc_part, str):
+        raise JlcImportError(
+            f"LCSC part number must be a string, got {type(lcsc_part)}"
+        )
+
+    normalized = lcsc_part.strip().upper()
+    if not LCSC_PART_PATTERN.match(normalized):
+        raise JlcImportError(
+            f"Invalid LCSC part number '{lcsc_part}', expected format C<digits>"
+        )
+
+    return normalized
+
+
+@dataclass
+class JlcPartSpec:
+    """
+    Resolved description of a JLCPCB part ready to be turned into a Component.
+
+    Attributes:
+        lcsc_part: LCSC part number, for example "C25804".
+        manufacturer_part: Manufacturer part number.
+        manufacturer: Manufacturer name.
+        description: Catalog description of the part.
+        package: JLCPCB package name, for example "0603" or "SOIC-8".
+        stock: Reported stock quantity.
+        basic_part: True for JLCPCB basic parts, False for extended parts.
+        price: Price string as reported by JLCPCB, empty when unknown.
+        symbol: Resolved KiCad symbol, None when no mapping was found.
+        footprint: Resolved KiCad footprint, None when no mapping was found.
+        value: Component value for passives, None when not applicable.
+        ref_prefix: Reference designator prefix, for example "R" or "U".
+        symbol_verified: True when the symbol comes from a verified mapping.
+        footprint_verified: True when the footprint comes from a verified mapping.
+    """
+
+    lcsc_part: str
+    manufacturer_part: str = ""
+    manufacturer: str = ""
+    description: str = ""
+    package: str = ""
+    stock: int = 0
+    basic_part: bool = False
+    price: str = ""
+    symbol: Optional[str] = None
+    footprint: Optional[str] = None
+    value: Optional[str] = None
+    ref_prefix: str = "U"
+    symbol_verified: bool = False
+    footprint_verified: bool = False
+
+    def to_properties(self) -> Dict[str, str]:
+        """
+        Build the component properties describing the JLCPCB sourcing data.
+
+        Returns:
+            Mapping of property name to value. Properties without data are
+            omitted so no empty fields end up in the netlist.
+        """
+        properties: Dict[str, str] = {"LCSC": self.lcsc_part}
+
+        if self.manufacturer_part:
+            properties["MPN"] = self.manufacturer_part
+        if self.manufacturer:
+            properties["Manufacturer"] = self.manufacturer
+        if self.package:
+            properties["JLCPCB_Package"] = self.package
+        if self.price:
+            properties["JLCPCB_Price"] = self.price
+
+        properties["JLCPCB_Stock"] = str(self.stock)
+        properties["JLCPCB_Part_Type"] = "Basic" if self.basic_part else "Extended"
+
+        return properties
+
+    def to_circuit_synth_code(self, ref: Optional[str] = None) -> str:
+        """
+        Render the part as a circuit-synth Component definition.
+
+        Args:
+            ref: Reference designator or prefix. Defaults to the resolved prefix.
+
+        Returns:
+            Python source for a Component definition.
+
+        Raises:
+            SymbolResolutionError: If no KiCad symbol has been resolved.
+        """
+        if not self.symbol:
+            raise SymbolResolutionError(
+                f"No KiCad symbol resolved for {self.lcsc_part}; "
+                "pass an explicit symbol to generate code"
+            )
+
+        lines = [f'    symbol="{self.symbol}",', f'    ref="{ref or self.ref_prefix}",']
+        if self.value:
+            lines.append(f'    value="{self.value}",')
+        if self.footprint:
+            lines.append(f'    footprint="{self.footprint}",')
+        for name, value in self.to_properties().items():
+            lines.append(f'    {name}="{value}",')
+
+        body = "\n".join(lines)
+        return f"Component(\n{body}\n)"
+
+
+class JlcComponentImporter:
+    """
+    Convert JLCPCB catalog entries into circuit-synth components.
+
+    The importer combines the JLCPCB search layer (part lookup) with the KiCad
+    symbol and footprint mappings of :class:`SmartComponentFinder`.
+    """
+
+    def __init__(
+        self,
+        searcher: Optional[FastJLCSearch] = None,
+        finder: Optional[SmartComponentFinder] = None,
+    ) -> None:
+        """
+        Initialize the importer.
+
+        Args:
+            searcher: Search backend used to look up LCSC part numbers.
+                Defaults to the shared fast searcher.
+            finder: Provider of the KiCad symbol and footprint mappings.
+                Defaults to a new SmartComponentFinder.
+        """
+        self._searcher = searcher if searcher is not None else get_fast_searcher()
+        self._finder = finder if finder is not None else SmartComponentFinder()
+
+    def resolve_part(self, lcsc_part: str) -> JlcPartSpec:
+        """
+        Look up an LCSC part number and resolve it to a part specification.
+
+        Args:
+            lcsc_part: LCSC part number, for example "C25804".
+
+        Returns:
+            The resolved part specification.
+
+        Raises:
+            JlcImportError: If the part number is not a valid LCSC part number.
+            JlcLookupError: If the search backend could not be queried.
+            JlcPartNotFoundError: If no catalog entry matches the part number.
+        """
+        normalized = normalize_lcsc_part(lcsc_part)
+
+        try:
+            results = self._searcher.search(
+                normalized, max_results=_LOOKUP_RESULT_LIMIT
+            )
+        except Exception as error:
+            logger.error(f"JLCPCB lookup failed for {normalized}: {error}")
+            raise JlcLookupError(
+                f"Could not query JLCPCB for {normalized}: {error}"
+            ) from error
+
+        match = self._select_exact_match(results, normalized)
+        if match is None:
+            raise JlcPartNotFoundError(
+                f"No JLCPCB catalog entry found for {normalized}"
+            )
+
+        logger.info(f"Resolved JLCPCB part {normalized} to {match.manufacturer_part}")
+        return self.spec_from_search_result(match)
+
+    def spec_from_search_result(self, result: FastSearchResult) -> JlcPartSpec:
+        """
+        Build a part specification from a search result.
+
+        Args:
+            result: Search result produced by the JLCPCB search layer.
+
+        Returns:
+            The resolved part specification.
+        """
+        return self.spec_from_catalog_entry(
+            {
+                "lcsc_part": result.part_number,
+                "part_number": result.manufacturer_part,
+                "description": result.description,
+                "package": result.package,
+                "stock": result.stock,
+                "price": f"${result.price:.4f}" if result.price else "",
+                "library_type": "Basic" if result.basic_part else "Extended",
+            }
+        )
+
+    def spec_from_catalog_entry(self, entry: Mapping[str, Any]) -> JlcPartSpec:
+        """
+        Build a part specification from a raw JLCPCB catalog dictionary.
+
+        Args:
+            entry: Catalog entry as returned by the JLCPCB scraper. Recognized
+                keys are ``lcsc_part``, ``part_number``, ``manufacturer``,
+                ``description``, ``package``, ``stock``, ``price`` and
+                ``library_type``.
+
+        Returns:
+            The resolved part specification.
+        """
+        lookup: Dict[str, Any] = {
+            "part_number": entry.get("part_number", ""),
+            "description": entry.get("description", ""),
+            "package": entry.get("package", ""),
+        }
+
+        symbol_info = self._finder.find_kicad_symbol(lookup)
+        footprint_info = self._finder.find_kicad_footprint(lookup)
+        symbol = symbol_info["symbol"] if symbol_info else None
+
+        value: Optional[str] = None
+        if symbol and self._finder.is_passive_component(symbol):
+            value = self._finder.extract_component_value(lookup)
+
+        spec = JlcPartSpec(
+            lcsc_part=str(entry.get("lcsc_part", "")),
+            manufacturer_part=str(entry.get("part_number", "")),
+            manufacturer=str(entry.get("manufacturer", "")),
+            description=str(entry.get("description", "")),
+            package=str(entry.get("package", "")),
+            stock=int(entry.get("stock", 0) or 0),
+            basic_part="basic" in str(entry.get("library_type", "")).lower(),
+            price=str(entry.get("price", "") or ""),
+            symbol=symbol,
+            footprint=footprint_info["footprint"] if footprint_info else None,
+            value=value,
+            ref_prefix=(
+                self._finder.reference_designator_for(symbol) if symbol else "U"
+            ),
+            symbol_verified=bool(symbol_info and symbol_info.get("verified")),
+            footprint_verified=bool(footprint_info and footprint_info.get("verified")),
+        )
+
+        if spec.symbol is None:
+            logger.warning(
+                f"No KiCad symbol mapping for {spec.lcsc_part} "
+                f"({spec.manufacturer_part or 'unknown part'})"
+            )
+
+        return spec
+
+    def build_component(
+        self,
+        spec: JlcPartSpec,
+        ref: Optional[str] = None,
+        symbol: Optional[str] = None,
+        footprint: Optional[str] = None,
+        value: Optional[str] = None,
+        **properties: Any,
+    ) -> Component:
+        """
+        Create a circuit-synth Component from a part specification.
+
+        Args:
+            spec: Resolved part specification.
+            ref: Reference designator or prefix. Defaults to the resolved prefix.
+            symbol: KiCad symbol override.
+            footprint: KiCad footprint override.
+            value: Component value override.
+            **properties: Additional component properties. They take precedence
+                over the JLCPCB sourcing properties of the same name.
+
+        Returns:
+            A Component with the JLCPCB sourcing metadata attached.
+
+        Raises:
+            SymbolResolutionError: If no symbol was resolved and none was given.
+        """
+        resolved_symbol = symbol or spec.symbol
+        if not resolved_symbol:
+            raise SymbolResolutionError(
+                f"No KiCad symbol resolved for {spec.lcsc_part}; "
+                "pass symbol= to create the component explicitly"
+            )
+
+        resolved_footprint = footprint or spec.footprint
+        if not resolved_footprint:
+            logger.warning(
+                f"No KiCad footprint resolved for {spec.lcsc_part} "
+                f"(package '{spec.package}'), component created without footprint"
+            )
+
+        component_properties: Dict[str, Any] = dict(spec.to_properties())
+        component_properties.update(properties)
+
+        component = Component(
+            symbol=resolved_symbol,
+            ref=ref or spec.ref_prefix,
+            value=value or spec.value,
+            footprint=resolved_footprint,
+            description=spec.description or None,
+            **component_properties,
+        )
+
+        logger.debug(
+            f"Created component for {spec.lcsc_part} using symbol {resolved_symbol}"
+        )
+        return component
+
+    def import_component(
+        self,
+        lcsc_part: str,
+        ref: Optional[str] = None,
+        symbol: Optional[str] = None,
+        footprint: Optional[str] = None,
+        value: Optional[str] = None,
+        **properties: Any,
+    ) -> Component:
+        """
+        Look up an LCSC part number and create the matching Component.
+
+        Args:
+            lcsc_part: LCSC part number, for example "C25804".
+            ref: Reference designator or prefix.
+            symbol: KiCad symbol override.
+            footprint: KiCad footprint override.
+            value: Component value override.
+            **properties: Additional component properties.
+
+        Returns:
+            A Component with the JLCPCB sourcing metadata attached.
+
+        Raises:
+            JlcImportError: If the part could not be resolved or created.
+        """
+        spec = self.resolve_part(lcsc_part)
+        return self.build_component(
+            spec,
+            ref=ref,
+            symbol=symbol,
+            footprint=footprint,
+            value=value,
+            **properties,
+        )
+
+    @staticmethod
+    def _select_exact_match(
+        results: List[FastSearchResult], lcsc_part: str
+    ) -> Optional[FastSearchResult]:
+        """
+        Select the result matching an LCSC part number exactly.
+
+        Args:
+            results: Search results to inspect.
+            lcsc_part: Normalized LCSC part number.
+
+        Returns:
+            The matching result, or None when no result matches.
+        """
+        for result in results:
+            if result.part_number.strip().upper() == lcsc_part:
+                return result
+        return None
+
+
+_default_importer: Optional[JlcComponentImporter] = None
+
+
+def get_component_importer() -> JlcComponentImporter:
+    """
+    Get the shared component importer instance.
+
+    Returns:
+        The process wide JlcComponentImporter, created on first use.
+    """
+    global _default_importer
+    if _default_importer is None:
+        _default_importer = JlcComponentImporter()
+    return _default_importer
+
+
+def import_jlc_component(
+    lcsc_part: str,
+    ref: Optional[str] = None,
+    symbol: Optional[str] = None,
+    footprint: Optional[str] = None,
+    value: Optional[str] = None,
+    importer: Optional[JlcComponentImporter] = None,
+    **properties: Any,
+) -> Component:
+    """
+    Import a JLCPCB part as a circuit-synth Component.
+
+    Args:
+        lcsc_part: LCSC part number, for example "C25804".
+        ref: Reference designator or prefix.
+        symbol: KiCad symbol override.
+        footprint: KiCad footprint override.
+        value: Component value override.
+        importer: Importer to use, defaults to the shared importer.
+        **properties: Additional component properties.
+
+    Returns:
+        A Component with the JLCPCB sourcing metadata attached.
+
+    Raises:
+        JlcImportError: If the part could not be resolved or created.
+    """
+    active_importer = importer if importer is not None else get_component_importer()
+    return active_importer.import_component(
+        lcsc_part,
+        ref=ref,
+        symbol=symbol,
+        footprint=footprint,
+        value=value,
+        **properties,
+    )
+
+
+def component_from_search_result(
+    result: FastSearchResult,
+    ref: Optional[str] = None,
+    symbol: Optional[str] = None,
+    footprint: Optional[str] = None,
+    value: Optional[str] = None,
+    importer: Optional[JlcComponentImporter] = None,
+    **properties: Any,
+) -> Component:
+    """
+    Create a Component from an existing JLCPCB search result.
+
+    No additional lookup is performed, so this works with results that were
+    obtained earlier or read from the search cache.
+
+    Args:
+        result: Search result produced by the JLCPCB search layer.
+        ref: Reference designator or prefix.
+        symbol: KiCad symbol override.
+        footprint: KiCad footprint override.
+        value: Component value override.
+        importer: Importer to use, defaults to the shared importer.
+        **properties: Additional component properties.
+
+    Returns:
+        A Component with the JLCPCB sourcing metadata attached.
+
+    Raises:
+        SymbolResolutionError: If no symbol was resolved and none was given.
+    """
+    active_importer = importer if importer is not None else get_component_importer()
+    spec = active_importer.spec_from_search_result(result)
+    return active_importer.build_component(
+        spec,
+        ref=ref,
+        symbol=symbol,
+        footprint=footprint,
+        value=value,
+        **properties,
+    )
+
+
+def lookup_lcsc_part(
+    lcsc_part: str, importer: Optional[JlcComponentImporter] = None
+) -> Optional[JlcPartSpec]:
+    """
+    Look up an LCSC part number without raising on failure.
+
+    Args:
+        lcsc_part: LCSC part number, for example "C25804".
+        importer: Importer to use, defaults to the shared importer.
+
+    Returns:
+        The resolved part specification, or None when the part could not be
+        resolved because it does not exist or the lookup was unavailable.
+    """
+    active_importer = importer if importer is not None else get_component_importer()
+    try:
+        return active_importer.resolve_part(lcsc_part)
+    except JlcImportError as error:
+        logger.warning(
+            f"JLCPCB lookup for {lcsc_part} returned no usable data: {error}"
+        )
+        return None

--- a/src/circuit_synth/manufacturing/jlcpcb/smart_component_finder.py
+++ b/src/circuit_synth/manufacturing/jlcpcb/smart_component_finder.py
@@ -140,6 +140,72 @@ class SmartComponentFinder:
 
         return self.find_components(family, max_results=max_alternatives)
 
+    def find_kicad_symbol(self, component: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        """
+        Resolve the KiCad symbol for a JLCPCB catalog entry.
+
+        Args:
+            component: Catalog entry with at least "part_number" and
+                "description" keys.
+
+        Returns:
+            Dictionary with "symbol" and "verified" keys, or None when no
+            mapping could be determined.
+        """
+        return self._find_kicad_symbol(component)
+
+    def find_kicad_footprint(
+        self, component: Dict[str, Any]
+    ) -> Optional[Dict[str, Any]]:
+        """
+        Resolve the KiCad footprint for a JLCPCB catalog entry.
+
+        Args:
+            component: Catalog entry with at least a "package" key.
+
+        Returns:
+            Dictionary with "footprint" and "verified" keys, or None when no
+            mapping could be determined.
+        """
+        return self._find_kicad_footprint(component)
+
+    def reference_designator_for(self, symbol: str) -> str:
+        """
+        Get the reference designator prefix for a KiCad symbol.
+
+        Args:
+            symbol: KiCad symbol identifier, for example "Device:R".
+
+        Returns:
+            Reference designator prefix, for example "R". Defaults to "U".
+        """
+        return self._get_reference_designator(symbol)
+
+    def is_passive_component(self, symbol: str) -> bool:
+        """
+        Check whether a KiCad symbol represents a passive component.
+
+        Args:
+            symbol: KiCad symbol identifier, for example "Device:R".
+
+        Returns:
+            True when the symbol is a resistor, capacitor or inductor.
+        """
+        return self._is_passive_component(symbol)
+
+    def extract_component_value(self, component: Dict[str, Any]) -> Optional[str]:
+        """
+        Extract the component value from a JLCPCB catalog entry.
+
+        Args:
+            component: Catalog entry with a "description" key.
+
+        Returns:
+            The parsed value, for example "10K", or None when no value could
+            be extracted.
+        """
+        return self._extract_component_value(component)
+
     def _create_recommendation(
         self, jlc_component: Dict[str, Any]
     ) -> Optional[ComponentRecommendation]:

--- a/src/circuit_synth/tools/jlc_fast_search_cli.py
+++ b/src/circuit_synth/tools/jlc_fast_search_cli.py
@@ -17,9 +17,11 @@ from rich.table import Table
 from rich.text import Text
 
 from circuit_synth.manufacturing.jlcpcb import (
+    JlcImportError,
     fast_jlc_search,
     find_cheapest_jlc,
     find_most_available_jlc,
+    get_component_importer,
     get_fast_searcher,
 )
 
@@ -231,6 +233,83 @@ def alternatives(part_number: str, max_results: int):
         table.add_row(result.part_number, desc, stock_str, price_str, result.package)
 
     console.print(table)
+
+
+@cli.command("import")
+@click.argument("lcsc_part")
+@click.option("--ref", "-r", default=None, help="Reference designator or prefix")
+@click.option("--symbol", default=None, help="Override the resolved KiCad symbol")
+@click.option("--footprint", default=None, help="Override the resolved KiCad footprint")
+@click.option("--json", "output_json", is_flag=True, help="Output as JSON")
+def import_part(
+    lcsc_part: str,
+    ref: str,
+    symbol: str,
+    footprint: str,
+    output_json: bool,
+) -> None:
+    """
+    Import an LCSC part as a circuit-synth component definition.
+
+    Example:
+        jlc-fast import C25804
+    """
+    importer = get_component_importer()
+
+    try:
+        spec = importer.resolve_part(lcsc_part)
+    except JlcImportError as error:
+        console.print(f"[red]{error}[/red]")
+        raise SystemExit(1)
+
+    if symbol:
+        spec.symbol = symbol
+    if footprint:
+        spec.footprint = footprint
+
+    if not spec.symbol:
+        console.print(
+            f"[red]No KiCad symbol mapping for {spec.lcsc_part}; "
+            f"rerun with --symbol[/red]"
+        )
+        raise SystemExit(1)
+
+    code = spec.to_circuit_synth_code(ref=ref)
+
+    if output_json:
+        output = {
+            "lcsc_part": spec.lcsc_part,
+            "manufacturer_part": spec.manufacturer_part,
+            "manufacturer": spec.manufacturer,
+            "description": spec.description,
+            "package": spec.package,
+            "stock": spec.stock,
+            "basic_part": spec.basic_part,
+            "symbol": spec.symbol,
+            "footprint": spec.footprint,
+            "value": spec.value,
+            "properties": spec.to_properties(),
+            "circuit_synth_code": code,
+        }
+        print(json.dumps(output, indent=2))
+        return
+
+    table = Table(title=f"JLCPCB part {spec.lcsc_part}")
+    table.add_column("Field", style="cyan")
+    table.add_column("Value", style="white")
+    table.add_row("Manufacturer part", spec.manufacturer_part or "-")
+    table.add_row("Manufacturer", spec.manufacturer or "-")
+    table.add_row("Description", spec.description or "-")
+    table.add_row("Package", spec.package or "-")
+    table.add_row("Stock", f"{spec.stock:,}")
+    table.add_row("Part type", "Basic" if spec.basic_part else "Extended")
+    table.add_row("Symbol", spec.symbol)
+    table.add_row("Footprint", spec.footprint or "unresolved")
+    table.add_row("Value", spec.value or "-")
+    console.print(table)
+
+    console.print("\nCircuit-synth component:\n")
+    console.print(code)
 
 
 @cli.command()

--- a/tests/unit/jlc_integration/test_jlc_component_import.py
+++ b/tests/unit/jlc_integration/test_jlc_component_import.py
@@ -1,0 +1,425 @@
+"""
+Tests for JLCPCB component import.
+
+These tests never touch the network: the JLCPCB search layer is mocked so that
+both the success paths and the failure/fallback paths are exercised
+deterministically.
+"""
+
+import logging
+import unittest
+from typing import Any, Dict, List
+from unittest.mock import patch
+
+from circuit_synth.core.circuit import Circuit
+from circuit_synth.core.decorators import get_current_circuit, set_current_circuit
+from circuit_synth.manufacturing.jlcpcb.component_import import (
+    JlcComponentImporter,
+    JlcImportError,
+    JlcLookupError,
+    JlcPartNotFoundError,
+    JlcPartSpec,
+    SymbolResolutionError,
+    component_from_search_result,
+    get_component_importer,
+    import_jlc_component,
+    lookup_lcsc_part,
+    normalize_lcsc_part,
+)
+from circuit_synth.manufacturing.jlcpcb.fast_search import FastSearchResult
+
+RESISTOR_RESULT = FastSearchResult(
+    part_number="C25804",
+    manufacturer_part="RC0603FR-0710KL",
+    description="10K Ohm Resistor, 1%, 1/10W",
+    stock=956234,
+    price=0.003,
+    package="0603",
+    basic_part=True,
+    match_score=1.0,
+)
+
+OPAMP_RESULT = FastSearchResult(
+    part_number="C7950",
+    manufacturer_part="LM358DR",
+    description="Dual Operational Amplifier",
+    stock=89234,
+    price=0.15,
+    package="SOIC-8",
+    basic_part=False,
+    match_score=1.0,
+)
+
+SCRAPER_ROW: Dict[str, Any] = {
+    "part_number": "AMS1117-3.3",
+    "lcsc_part": "C6186",
+    "manufacturer": "Advanced Monolithic Systems",
+    "description": "3.3V Linear Voltage Regulator, 1A",
+    "package": "SOT-223",
+    "stock": 234567,
+    "price": "$0.08@100pcs",
+    "library_type": "Basic",
+}
+
+
+class _StubSearcher:
+    """Minimal stand-in for FastJLCSearch that never performs I/O."""
+
+    def __init__(
+        self,
+        results: List[FastSearchResult] = None,
+        error: Exception = None,
+    ) -> None:
+        self.results = results or []
+        self.error = error
+        self.queries: List[str] = []
+
+    def search(self, query: str, **kwargs: Any) -> List[FastSearchResult]:
+        """Return the canned results or raise the canned error."""
+        self.queries.append(query)
+        if self.error is not None:
+            raise self.error
+        return list(self.results)
+
+
+def _make_importer(
+    results: List[FastSearchResult] = None, error: Exception = None
+) -> JlcComponentImporter:
+    """Build an importer backed by a stub searcher."""
+    return JlcComponentImporter(searcher=_StubSearcher(results=results, error=error))
+
+
+class TestNormalizeLcscPart(unittest.TestCase):
+    """Validation and normalization of LCSC part numbers."""
+
+    def test_uppercases_and_strips_whitespace(self):
+        """Lower case input with surrounding whitespace is normalized."""
+        self.assertEqual(normalize_lcsc_part("  c25804 "), "C25804")
+
+    def test_accepts_canonical_form(self):
+        """An already canonical part number is returned unchanged."""
+        self.assertEqual(normalize_lcsc_part("C25804"), "C25804")
+
+    def test_rejects_missing_prefix(self):
+        """A part number without the C prefix is rejected."""
+        with self.assertRaises(JlcImportError):
+            normalize_lcsc_part("25804")
+
+    def test_rejects_empty_value(self):
+        """An empty string is rejected."""
+        with self.assertRaises(JlcImportError):
+            normalize_lcsc_part("   ")
+
+    def test_rejects_non_numeric_suffix(self):
+        """A part number with a non numeric suffix is rejected."""
+        with self.assertRaises(JlcImportError):
+            normalize_lcsc_part("C25804A")
+
+
+class TestJlcPartSpec(unittest.TestCase):
+    """Conversion of JLCPCB catalog data into a part specification."""
+
+    def setUp(self):
+        self.importer = _make_importer()
+
+    def test_spec_from_search_result_resolves_symbol_and_footprint(self):
+        """A passive search result maps to a KiCad symbol, footprint and value."""
+        spec = self.importer.spec_from_search_result(RESISTOR_RESULT)
+
+        self.assertEqual(spec.lcsc_part, "C25804")
+        self.assertEqual(spec.manufacturer_part, "RC0603FR-0710KL")
+        self.assertEqual(spec.symbol, "Device:R")
+        self.assertEqual(spec.footprint, "Resistor_SMD:R_0603_1608Metric")
+        self.assertEqual(spec.value, "10K")
+        self.assertEqual(spec.ref_prefix, "R")
+        self.assertTrue(spec.basic_part)
+        self.assertEqual(spec.stock, 956234)
+
+    def test_spec_from_search_result_for_integrated_circuit(self):
+        """An IC search result maps to a U reference prefix and no value."""
+        spec = self.importer.spec_from_search_result(OPAMP_RESULT)
+
+        self.assertEqual(spec.symbol, "Amplifier_Operational:LM358")
+        self.assertEqual(spec.footprint, "Package_SO:SOIC-8_3.9x4.9mm_P1.27mm")
+        self.assertEqual(spec.ref_prefix, "U")
+        self.assertIsNone(spec.value)
+        self.assertFalse(spec.basic_part)
+
+    def test_spec_from_catalog_entry_reads_scraper_dictionary(self):
+        """Raw scraper dictionaries are accepted as an input format."""
+        spec = self.importer.spec_from_catalog_entry(SCRAPER_ROW)
+
+        self.assertEqual(spec.lcsc_part, "C6186")
+        self.assertEqual(spec.manufacturer_part, "AMS1117-3.3")
+        self.assertEqual(spec.manufacturer, "Advanced Monolithic Systems")
+        self.assertEqual(spec.symbol, "Regulator_Linear:AMS1117-3.3")
+        self.assertEqual(spec.footprint, "Package_TO_SOT_SMD:SOT-223-3_TabPin2")
+        self.assertTrue(spec.basic_part)
+        self.assertEqual(spec.price, "$0.08@100pcs")
+
+    def test_spec_without_mapping_leaves_symbol_unresolved(self):
+        """An unmapped component yields a spec without symbol or footprint."""
+        unknown = FastSearchResult(
+            part_number="C999999",
+            manufacturer_part="XYZ-1234",
+            description="Unclassified part",
+            stock=10,
+            price=1.0,
+            package="WeirdPackage",
+            basic_part=False,
+            match_score=0.1,
+        )
+
+        spec = self.importer.spec_from_search_result(unknown)
+
+        self.assertIsNone(spec.symbol)
+        self.assertIsNone(spec.footprint)
+
+    def test_to_properties_includes_sourcing_metadata(self):
+        """Sourcing metadata is exposed as component properties."""
+        spec = self.importer.spec_from_search_result(RESISTOR_RESULT)
+        properties = spec.to_properties()
+
+        self.assertEqual(properties["LCSC"], "C25804")
+        self.assertEqual(properties["MPN"], "RC0603FR-0710KL")
+        self.assertEqual(properties["JLCPCB_Stock"], "956234")
+        self.assertEqual(properties["JLCPCB_Part_Type"], "Basic")
+
+    def test_to_properties_marks_extended_parts(self):
+        """Extended parts are labelled as such in the properties."""
+        spec = self.importer.spec_from_search_result(OPAMP_RESULT)
+
+        self.assertEqual(spec.to_properties()["JLCPCB_Part_Type"], "Extended")
+
+    def test_to_properties_omits_missing_fields(self):
+        """Fields with no data are omitted rather than emitted empty."""
+        spec = JlcPartSpec(lcsc_part="C1", symbol="Device:R")
+        properties = spec.to_properties()
+
+        self.assertNotIn("MPN", properties)
+        self.assertNotIn("Manufacturer", properties)
+        self.assertNotIn("JLCPCB_Price", properties)
+
+    def test_to_circuit_synth_code_is_valid_python(self):
+        """The generated snippet compiles and contains the resolved fields."""
+        spec = self.importer.spec_from_search_result(RESISTOR_RESULT)
+        code = spec.to_circuit_synth_code()
+
+        compile(code, "<generated>", "exec")
+        self.assertIn('symbol="Device:R"', code)
+        self.assertIn('footprint="Resistor_SMD:R_0603_1608Metric"', code)
+        self.assertIn('LCSC="C25804"', code)
+
+    def test_to_circuit_synth_code_requires_symbol(self):
+        """Code generation fails when the symbol could not be resolved."""
+        spec = JlcPartSpec(lcsc_part="C1")
+
+        with self.assertRaises(SymbolResolutionError):
+            spec.to_circuit_synth_code()
+
+
+class TestResolvePart(unittest.TestCase):
+    """Lookup of an LCSC part number through the search layer."""
+
+    def test_resolve_part_returns_matching_entry(self):
+        """The result whose part number matches the query is selected."""
+        importer = _make_importer([OPAMP_RESULT, RESISTOR_RESULT])
+
+        spec = importer.resolve_part("c25804")
+
+        self.assertEqual(spec.lcsc_part, "C25804")
+        self.assertEqual(spec.symbol, "Device:R")
+
+    def test_resolve_part_uses_normalized_query(self):
+        """The searcher is queried with the normalized part number."""
+        searcher = _StubSearcher([RESISTOR_RESULT])
+        importer = JlcComponentImporter(searcher=searcher)
+
+        importer.resolve_part(" c25804 ")
+
+        self.assertEqual(searcher.queries, ["C25804"])
+
+    def test_resolve_part_raises_when_no_results(self):
+        """An empty result set raises JlcPartNotFoundError."""
+        importer = _make_importer([])
+
+        with self.assertRaises(JlcPartNotFoundError):
+            importer.resolve_part("C25804")
+
+    def test_resolve_part_raises_when_no_exact_match(self):
+        """Results that do not match the requested part are rejected."""
+        importer = _make_importer([OPAMP_RESULT])
+
+        with self.assertRaises(JlcPartNotFoundError):
+            importer.resolve_part("C25804")
+
+    def test_resolve_part_wraps_search_failures(self):
+        """Search layer exceptions are reported as JlcLookupError."""
+        importer = _make_importer(error=ConnectionError("network unreachable"))
+
+        with self.assertRaises(JlcLookupError):
+            importer.resolve_part("C25804")
+
+    def test_resolve_part_rejects_invalid_part_number(self):
+        """Invalid part numbers fail before any search is attempted."""
+        searcher = _StubSearcher([RESISTOR_RESULT])
+        importer = JlcComponentImporter(searcher=searcher)
+
+        with self.assertRaises(JlcImportError):
+            importer.resolve_part("not-a-part")
+
+        self.assertEqual(searcher.queries, [])
+
+
+class TestLookupLcscPart(unittest.TestCase):
+    """Non raising lookup helper."""
+
+    def test_returns_spec_on_success(self):
+        """A resolvable part returns its specification."""
+        importer = _make_importer([RESISTOR_RESULT])
+
+        spec = lookup_lcsc_part("C25804", importer=importer)
+
+        self.assertIsNotNone(spec)
+        self.assertEqual(spec.lcsc_part, "C25804")
+
+    def test_returns_none_when_lookup_fails(self):
+        """A failed lookup degrades to None instead of raising."""
+        importer = _make_importer(error=ConnectionError("network unreachable"))
+
+        self.assertIsNone(lookup_lcsc_part("C25804", importer=importer))
+
+    def test_returns_none_for_invalid_part_number(self):
+        """An invalid part number degrades to None."""
+        importer = _make_importer([RESISTOR_RESULT])
+
+        self.assertIsNone(lookup_lcsc_part("bogus", importer=importer))
+
+    def test_logs_warning_when_lookup_fails(self):
+        """A failed lookup is logged at warning level."""
+        importer = _make_importer([])
+
+        with self.assertLogs(
+            "circuit_synth.manufacturing.jlcpcb.component_import", level=logging.WARNING
+        ) as captured:
+            lookup_lcsc_part("C25804", importer=importer)
+
+        self.assertTrue(any("C25804" in message for message in captured.output))
+
+
+class TestBuildComponent(unittest.TestCase):
+    """Construction of circuit-synth components from JLCPCB data."""
+
+    def setUp(self):
+        self._previous_circuit = get_current_circuit()
+        set_current_circuit(Circuit(name="JlcImportTest"))
+
+    def tearDown(self):
+        set_current_circuit(self._previous_circuit)
+
+    def test_import_jlc_component_returns_usable_component(self):
+        """A known LCSC part becomes a component with symbol, value and metadata."""
+        importer = _make_importer([RESISTOR_RESULT])
+
+        component = import_jlc_component("C25804", importer=importer)
+
+        self.assertEqual(component.symbol, "Device:R")
+        self.assertEqual(component.footprint, "Resistor_SMD:R_0603_1608Metric")
+        self.assertEqual(component.value, "10K")
+        self.assertEqual(component.LCSC, "C25804")
+        self.assertEqual(component.MPN, "RC0603FR-0710KL")
+        self.assertEqual(component.JLCPCB_Part_Type, "Basic")
+        self.assertEqual(component.JLCPCB_Stock, "956234")
+        self.assertEqual(len(component._pins), 2)
+
+    def test_import_jlc_component_applies_overrides(self):
+        """Caller supplied symbol, footprint, value and reference win."""
+        importer = _make_importer([RESISTOR_RESULT])
+
+        component = import_jlc_component(
+            "C25804",
+            ref="R42",
+            symbol="Device:C",
+            footprint="Capacitor_SMD:C_0603_1608Metric",
+            value="100nF",
+            importer=importer,
+        )
+
+        self.assertEqual(component.symbol, "Device:C")
+        self.assertEqual(component.footprint, "Capacitor_SMD:C_0603_1608Metric")
+        self.assertEqual(component.value, "100nF")
+        self.assertEqual(component.ref, "R42")
+
+    def test_import_jlc_component_accepts_extra_properties(self):
+        """Additional properties are attached to the component."""
+        importer = _make_importer([RESISTOR_RESULT])
+
+        component = import_jlc_component("C25804", importer=importer, Tolerance="1%")
+
+        self.assertEqual(component.Tolerance, "1%")
+
+    def test_component_from_search_result_skips_lookup(self):
+        """A search result can be converted without any further search."""
+        searcher = _StubSearcher(error=AssertionError("search must not run"))
+        importer = JlcComponentImporter(searcher=searcher)
+
+        component = component_from_search_result(RESISTOR_RESULT, importer=importer)
+
+        self.assertEqual(component.symbol, "Device:R")
+        self.assertEqual(component.LCSC, "C25804")
+
+    def test_build_component_requires_a_symbol(self):
+        """A spec without a resolvable symbol raises SymbolResolutionError."""
+        importer = _make_importer()
+        spec = JlcPartSpec(lcsc_part="C999999", manufacturer_part="XYZ-1234")
+
+        with self.assertRaises(SymbolResolutionError):
+            importer.build_component(spec)
+
+    def test_build_component_without_footprint_logs_warning(self):
+        """A missing footprint is a warning, not a failure."""
+        importer = _make_importer()
+        spec = JlcPartSpec(lcsc_part="C25804", symbol="Device:R", ref_prefix="R")
+
+        with self.assertLogs(
+            "circuit_synth.manufacturing.jlcpcb.component_import", level=logging.WARNING
+        ) as captured:
+            component = importer.build_component(spec)
+
+        self.assertIsNone(component.footprint)
+        self.assertTrue(any("C25804" in message for message in captured.output))
+
+    def test_build_component_uses_reference_prefix_by_default(self):
+        """Without an explicit reference the mapped prefix is used."""
+        importer = _make_importer([RESISTOR_RESULT])
+        spec = importer.resolve_part("C25804")
+
+        component = importer.build_component(spec)
+
+        self.assertTrue(component.ref.startswith("R"))
+
+    def test_import_jlc_component_propagates_not_found(self):
+        """An unknown part propagates JlcPartNotFoundError to the caller."""
+        importer = _make_importer([])
+
+        with self.assertRaises(JlcPartNotFoundError):
+            import_jlc_component("C25804", importer=importer)
+
+
+class TestDefaultImporter(unittest.TestCase):
+    """Module level importer accessor."""
+
+    def test_get_component_importer_is_cached(self):
+        """The default importer is created once and reused."""
+        with patch(
+            "circuit_synth.manufacturing.jlcpcb.component_import._default_importer",
+            None,
+        ):
+            first = get_component_importer()
+            second = get_component_importer()
+
+        self.assertIs(first, second)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/tools/test_jlc_fast_search_cli.py
+++ b/tests/unit/tools/test_jlc_fast_search_cli.py
@@ -1,0 +1,112 @@
+"""
+Unit tests for the jlc-fast CLI import command.
+
+The JLCPCB lookup is mocked so the tests run without network access.
+"""
+
+import json
+import unittest
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from circuit_synth.manufacturing.jlcpcb.component_import import (
+    JlcPartNotFoundError,
+    JlcPartSpec,
+)
+from circuit_synth.tools.jlc_fast_search_cli import cli
+
+RESISTOR_SPEC = JlcPartSpec(
+    lcsc_part="C25804",
+    manufacturer_part="RC0603FR-0710KL",
+    manufacturer="YAGEO",
+    description="10K Ohm Resistor, 1%, 1/10W",
+    package="0603",
+    stock=956234,
+    basic_part=True,
+    price="$0.0030",
+    symbol="Device:R",
+    footprint="Resistor_SMD:R_0603_1608Metric",
+    value="10K",
+    ref_prefix="R",
+)
+
+
+class TestImportCommand(unittest.TestCase):
+    """Behavior of `jlc-fast import`."""
+
+    def setUp(self):
+        self.runner = CliRunner()
+
+    def _run(self, importer: MagicMock, args):
+        """Run the CLI with a mocked importer."""
+        with patch(
+            "circuit_synth.tools.jlc_fast_search_cli.get_component_importer",
+            return_value=importer,
+        ):
+            return self.runner.invoke(cli, args)
+
+    def test_import_prints_component_definition(self):
+        """A resolvable part prints its metadata and component definition."""
+        importer = MagicMock()
+        importer.resolve_part.return_value = RESISTOR_SPEC
+
+        result = self._run(importer, ["import", "C25804"])
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("Device:R", result.output)
+        self.assertIn("C25804", result.output)
+        importer.resolve_part.assert_called_once_with("C25804")
+
+    def test_import_json_output_is_machine_readable(self):
+        """The --json flag emits the resolved part as JSON."""
+        importer = MagicMock()
+        importer.resolve_part.return_value = RESISTOR_SPEC
+
+        result = self._run(importer, ["import", "C25804", "--json"])
+
+        self.assertEqual(result.exit_code, 0)
+        payload = json.loads(result.output)
+        self.assertEqual(payload["lcsc_part"], "C25804")
+        self.assertEqual(payload["symbol"], "Device:R")
+        self.assertEqual(payload["properties"]["JLCPCB_Part_Type"], "Basic")
+
+    def test_import_reports_unknown_part(self):
+        """An unresolvable part exits with a non zero status."""
+        importer = MagicMock()
+        importer.resolve_part.side_effect = JlcPartNotFoundError(
+            "No JLCPCB catalog entry found for C999999"
+        )
+
+        result = self._run(importer, ["import", "C999999"])
+
+        self.assertEqual(result.exit_code, 1)
+        self.assertIn("C999999", result.output)
+
+    def test_import_requires_symbol_when_unmapped(self):
+        """A part without a symbol mapping asks for an explicit symbol."""
+        importer = MagicMock()
+        importer.resolve_part.return_value = JlcPartSpec(lcsc_part="C999999")
+
+        result = self._run(importer, ["import", "C999999"])
+
+        self.assertEqual(result.exit_code, 1)
+        self.assertIn("--symbol", result.output)
+
+    def test_import_accepts_symbol_override(self):
+        """An explicit symbol override is used for code generation."""
+        importer = MagicMock()
+        importer.resolve_part.return_value = JlcPartSpec(lcsc_part="C999999")
+
+        result = self._run(
+            importer,
+            ["import", "C999999", "--symbol", "Device:R", "--json"],
+        )
+
+        self.assertEqual(result.exit_code, 0)
+        payload = json.loads(result.output)
+        self.assertEqual(payload["symbol"], "Device:R")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds support for importing JLCPCB/LCSC parts as circuit-synth components. Until now the JLCPCB integration could search for parts and print a code snippet, but there was no supported way to go from an LCSC part number to a `Component` object with the sourcing data attached.

New module: `src/circuit_synth/manufacturing/jlcpcb/component_import.py`.

## Public API

```python
from circuit_synth.manufacturing.jlcpcb import import_jlc_component

r1 = import_jlc_component("C25804")
# Component(symbol="Device:R", ref="R", value="10K",
#           footprint="Resistor_SMD:R_0603_1608Metric",
#           LCSC="C25804", MPN="RC0603FR-0710KL", Manufacturer="YAGEO",
#           JLCPCB_Stock="956234", JLCPCB_Part_Type="Basic")
```

- `import_jlc_component(lcsc_part, ref=None, symbol=None, footprint=None, value=None, **properties) -> Component` - look up an LCSC part number and build the component.
- `component_from_search_result(result, ...) -> Component` - build a component from an existing `FastSearchResult` without performing another lookup (works with cached results).
- `lookup_lcsc_part(lcsc_part) -> Optional[JlcPartSpec]` - non raising lookup for callers that want to fall back to a locally specified component.
- `JlcComponentImporter` - injectable class holding the search backend and the KiCad mapping provider; `resolve_part()`, `spec_from_search_result()`, `spec_from_catalog_entry()`, `build_component()`, `import_component()`.
- `JlcPartSpec` - resolved part data with `to_properties()` and `to_circuit_synth_code()`.
- `normalize_lcsc_part()` and the error hierarchy `JlcImportError` -> `JlcPartNotFoundError`, `JlcLookupError`, `SymbolResolutionError`.

Symbol, footprint, value and reference prefix are resolved through the existing `SmartComponentFinder` mappings, whose lookup helpers are now public methods (`find_kicad_symbol`, `find_kicad_footprint`, `reference_designator_for`, `is_passive_component`, `extract_component_value`) instead of being duplicated.

Component properties attached: `LCSC`, `MPN`, `Manufacturer`, `JLCPCB_Package`, `JLCPCB_Price`, `JLCPCB_Stock`, `JLCPCB_Part_Type` (Basic or Extended). Properties without data are omitted.

## CLI

```
jlc-fast import C25804            # resolved part data plus the Component definition
jlc-fast import C25804 --json     # machine readable output
jlc-fast import C999999 --symbol Device:R
```

## Degradation behavior

- Search backend exceptions are wrapped in `JlcLookupError`, so an unavailable or rate limited JLCPCB endpoint does not surface as an arbitrary exception; `lookup_lcsc_part()` returns `None` and logs a warning.
- No exact catalog match raises `JlcPartNotFoundError` (the CLI reports it and exits with status 1).
- A missing footprint mapping logs a warning and still produces a component.
- A missing symbol mapping raises `SymbolResolutionError` unless `symbol=` is supplied.

## Testing

38 new tests, all with the JLCPCB search layer mocked, so no network access is required:

- `tests/unit/jlc_integration/test_jlc_component_import.py` (33 tests) - part number normalization, symbol/footprint/value resolution for passives and ICs, property mapping, code generation, lookup success and failure paths, component construction, overrides and fallbacks.
- `tests/unit/tools/test_jlc_fast_search_cli.py` (5 tests) - the new CLI command including the unknown part and unmapped symbol paths.

```
$ pytest tests/unit/jlc_integration tests/unit/test_fast_jlc_search.py \
         tests/integration/test_fast_jlc_integration.py tests/unit/tools
189 passed, 3 skipped, 2 warnings in 4.25s
```

The 3 skips are the pre-existing network dependent JLCPCB integration tests. `black` and `isort` report no changes on the touched files.
